### PR TITLE
feat: publish XMemo Skill 1.1.2 source baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,34 @@ mcp-publisher.exe
 *_REPORT.md
 *-PROGRESS.md
 *_PROGRESS.md
+
+
+# DevFlow engine
+.progress/
+
+# Agent registry & profiles
+.agents/
+
+# GitHub Copilot agents & instructions (DevFlow-specific)
+.github/agents/
+.github/instructions/
+.github/copilot-instructions.md
+
+# VS Code workspace (contains DevFlow references)
+*.code-workspace
+
+# Runtime & state files
+.telegram_bridge_state.json
+STANDBY_STATE.json
+telegram_bridge_settings.json
+.github/hooks/devflow-lifecycle.json
+
+# === DevFlow Bridge Runtime ===
+# Runtime bridge files are local transport state and should not be versioned.
+# Added by: DevFlow standard deploy/init
+
+.progress/.bridge_inbox_*.tmp
+.progress/.bridge_delivery_claims/
+.progress/CHAT_BRIDGE_INBOX.jsonl
+.progress/CHAT_BRIDGE_OUTBOX.jsonl
+.progress/bridge_media/

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -6,7 +6,7 @@
   "authorUrl": "https://github.com/yonro",
   "homepage": "https://xmemo.dev/product/mcp",
   "icon": "https://raw.githubusercontent.com/yonro/memory-os-cli/main/plugins/xmemo/assets/logo.png",
-  "version": "0.4.179",
+  "version": "0.4.180",
   "category": "productivity",
   "connectionType": "hybrid",
   "cloudEndpoint": "https://xmemo.dev/mcp",

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -74,7 +74,7 @@
     },
     {
       "name": "recall_context",
-      "description": "Build a context pack from XMemo memories for complex tasks."
+      "description": "Read a multi-memory context pack with explicit item/token budgets; use recall for a lightweight answer or get_project_context for a project snapshot."
     },
     {
       "name": "memory_stats",
@@ -94,7 +94,7 @@
     },
     {
       "name": "add_expense",
-      "description": "Record one expense in the XMemo Ledger."
+      "description": "Create one XMemo Ledger transaction and backing memory for an expense, income, refund, or transfer."
     },
     {
       "name": "list_ledger_transactions",
@@ -126,7 +126,7 @@
     },
     {
       "name": "get_timeline",
-      "description": "Show recent timeline events."
+      "description": "Read authorized timeline events newest first; use recall_context for semantic multi-memory context."
     },
     {
       "name": "record_event",
@@ -134,11 +134,11 @@
     },
     {
       "name": "update_state",
-      "description": "Save the current working state during long-running work."
+      "description": "Create or replace scoped working state for resuming a task; use remember for durable facts."
     },
     {
       "name": "get_project_context",
-      "description": "Build project-scoped context from XMemo memories."
+      "description": "Read one authorized project's bounded context pack when an exact project_id is known."
     }
   ],
   "prompts": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xmemo/client",
-  "version": "0.4.179",
+  "version": "0.4.180",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xmemo/client",
-      "version": "0.4.179",
+      "version": "0.4.180",
       "license": "MIT",
       "bin": {
         "memory-os": "bin/memory-os.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmemo/client",
-  "version": "0.4.179",
+  "version": "0.4.180",
   "description": "Privacy-first CLI and MCP setup helper for XMemo.",
   "mcpName": "io.github.yonro/xmemo",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/yonro/memory-os-cli",
     "source": "github"
   },
-  "version": "0.4.179",
+  "version": "0.4.180",
   "remotes": [
     {
       "type": "streamable-http",
@@ -39,7 +39,7 @@
     {
       "registryType": "npm",
       "identifier": "@xmemo/client",
-      "version": "0.4.179",
+      "version": "0.4.180",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/skills/xmemo/CHANGELOG.md
+++ b/skills/xmemo/CHANGELOG.md
@@ -1,5 +1,19 @@
 # XMemo Skill Change Log
 
+## 1.1.1
+
+- `scripts/xmemo-skill.mjs`: add formal-account `restart-snapshot` and
+  `restart-restore` commands for the Memory OS v0.4.335 full-continuity
+  contract, without replacing the lightweight `save-state` / `restore-state`
+  workflow or widening temporary-agent permissions.
+- `scripts/xmemo-skill.mjs`: validate restart snapshot limits, TTLs, metadata,
+  and restore booleans; keep normal output bounded to IDs/timestamps while
+  retaining redacted `--json` output for trusted callers.
+- `SKILL.md` and references: explain when to use single-state handoff,
+  full restart continuity, or native MCP restart tools.
+- Tests: pin the advertised runtime version to the newest change-log heading so
+  a released section is never reopened for new work.
+
 ## 1.1.0
 
 - `scripts/xmemo-skill.mjs`: align the advertised and runtime version at `1.1.0` while preserving the `XMemo Memory` package identity and formal-account-first login policy.

--- a/skills/xmemo/CHANGELOG.md
+++ b/skills/xmemo/CHANGELOG.md
@@ -1,5 +1,16 @@
 # XMemo Skill Change Log
 
+## 1.1.2
+
+- `SKILL.md` and references: distinguish the public generic
+  `/v1/skill/operations` discovery list from the formal-account-only direct
+  restart-continuity routes. This prevents a missing restart entry in
+  `standalone_skill.operations` from being misread as an unavailable command.
+- Documentation and tests: clarify that temporary agents never receive restart
+  continuity, that discovery alone is not authorization, and that an
+  unauthenticated `401` is route reachability rather than a write-capability
+  proof.
+
 ## 1.1.1
 
 - `scripts/xmemo-skill.mjs`: add formal-account `restart-snapshot` and

--- a/skills/xmemo/SKILL.md
+++ b/skills/xmemo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xmemo-memory
-description: Persistent user-owned memory for agents with standalone runtime execution. Use when an agent should remember, recall, search memory, save or restore handoff state, manage TODOs, record expenses, diagnose XMemo auth, or operate XMemo even when MCP tools are not configured.
+description: Persistent user-owned memory for agents with standalone runtime execution. Use when an agent should remember, recall, search memory, preserve restart continuity, manage TODOs, record expenses, diagnose XMemo auth, or operate XMemo even when MCP tools are not configured.
 ---
 
 # XMemo Memory
@@ -79,8 +79,10 @@ Never ask the user to paste a raw token into chat, logs, or project files.
   project, task, and subsystem before making decisions.
 - **Remember durable facts.** Store decisions, conventions, preferences,
   architecture notes, release procedures, and verified troubleshooting steps.
-- **Preserve handoffs.** Use `save-state` and `restore-state` at milestones or
-  before stopping.
+- **Preserve handoffs.** Use `save-state` / `restore-state` for one active
+  task slot. Use `restart-snapshot` / `restart-restore` when a restart needs
+  the broader continuity pack: active state, recent events, TODOs, and pending
+  decisions.
 - **Record concrete expenses.** Use `expense-add` when the user states a concrete
   purchase or income.
 - **Confirm destructive actions.** The bundled script does not expose memory
@@ -97,6 +99,8 @@ node scripts/xmemo-skill.mjs recall --query "..." --compact
 node scripts/xmemo-skill.mjs search --query "..." --limit 5 --compact
 node scripts/xmemo-skill.mjs save-state --key active_task
 node scripts/xmemo-skill.mjs restore-state --key active_task
+node scripts/xmemo-skill.mjs restart-snapshot
+node scripts/xmemo-skill.mjs restart-restore
 node scripts/xmemo-skill.mjs todo-add --content "..."
 node scripts/xmemo-skill.mjs todo-list
 node scripts/xmemo-skill.mjs todo-done --id <todo_id>
@@ -109,6 +113,12 @@ node scripts/xmemo-skill.mjs register --reason <unattended|declined> --allow-pla
 The script supports JSON output with `--json`, command-specific usage with
 `--help`, `--version`, per-request timeouts with `--timeout-ms`, and compact
 recall/search output with `--compact`. It never prints token values or prefixes.
+
+When native XMemo MCP tools are present, use `create_restart_snapshot` and
+`restore_restart_snapshot` for the same full-continuity workflow. The bundled
+commands keep that capability available to standalone Skill hosts. These
+restart commands require a formal account credential; temporary sandboxes
+remain limited to `remember`, `recall`, and `search`.
 
 ## Direct CLI Commands
 
@@ -158,7 +168,9 @@ For detailed examples, read `references/operations.md`. For auth, network, and s
 
 ## Never Save
 
-- Secrets, tokens, API keys, OAuth codes, cookies, session IDs, or private keys.
+- Secrets, tokens, API keys, OAuth codes, cookies, authentication session IDs,
+  or private keys. Optional restart `session_id` values must be non-secret
+  correlation labels, never login/session credentials.
 - Private customer data or sensitive personal data unless the user explicitly asks
   and the memory tool supports the required privacy policy.
 - Temporary debugging output that will not help future work.

--- a/skills/xmemo/SKILL.md
+++ b/skills/xmemo/SKILL.md
@@ -16,6 +16,20 @@ XMemo supports two parallel integration paths:
 
 Run bundled commands from the Skill root with Node.js 20 or newer.
 
+## Hosted Discovery Boundary
+
+The public `agent-discovery` field `standalone_skill.operations` describes the
+generic commands accepted by `POST /v1/skill/operations`; it is not the full
+standalone command catalogue. `restart-snapshot` and `restart-restore` use the
+separate direct endpoints `/v1/restart/snapshot` and `/v1/restart/restore`, so
+they are deliberately absent from that operations list.
+
+Do not infer that a restart command is available merely because a discovery
+document mentions a memory scope. It requires a formal account credential and
+the service must authorize the specific request. The temporary-agent manifest
+intentionally omits restart continuity: temporary access stays limited to
+`remember`, `recall`, and `search` in its isolated sandbox.
+
 Credential lookup always prefers the `XMEMO_KEY` environment variable. When it
 is present, the script does not copy its value into a local credential file.
 

--- a/skills/xmemo/references/operations.md
+++ b/skills/xmemo/references/operations.md
@@ -92,6 +92,22 @@ temporary credential and removes pending confirmation data.
 | `auth claim-status` / `auth claim-confirm` / `auth claim-deny` | Inspect, approve, or reject the two-phase temporary bind |
 | `logout` | Revoke/remove a local credential; externally managed `XMEMO_KEY` requires explicit revocation |
 
+## Discovery boundary
+
+The public `/.well-known/agent-discovery.json` operation list is a contract for
+the generic `POST /v1/skill/operations` dispatcher. It intentionally does not
+enumerate every direct standalone endpoint. In particular,
+`restart-snapshot` and `restart-restore` use `/v1/restart/snapshot` and
+`/v1/restart/restore` directly, so they do not appear in
+`standalone_skill.operations`.
+
+This is a routing boundary, not permission evidence. A formal account still
+needs authorization for each restart request; an unauthenticated `401` only
+proves that the protected route is reachable. Do not create a real snapshot
+just to test a deployment. Temporary-agent discovery intentionally exposes no
+restart workflow, and temporary credentials remain limited to `remember`,
+`recall`, and `search`.
+
 ## Examples
 
 ### Remember a decision

--- a/skills/xmemo/references/operations.md
+++ b/skills/xmemo/references/operations.md
@@ -81,6 +81,8 @@ temporary credential and removes pending confirmation data.
 | `search` | Search memories by query |
 | `save-state` | Save current task handoff state |
 | `restore-state` | Restore current task handoff state |
+| `restart-snapshot` | Save active state, recent events, TODOs, and pending decisions as one restart snapshot |
+| `restart-restore` | Restore the latest or a selected restart snapshot |
 | `todo-add` | Create a TODO item |
 | `todo-list` | List TODO items |
 | `todo-done` | Mark a TODO done |
@@ -127,6 +129,35 @@ state behavior for that item.
 ```text
 node scripts/xmemo-skill.mjs restore-state --key active_task
 ```
+
+### Preserve full restart continuity
+
+Use a restart snapshot when the next agent/session needs more than the single
+active-state slot:
+
+```text
+node scripts/xmemo-skill.mjs restart-snapshot
+node scripts/xmemo-skill.mjs restart-restore
+```
+
+`restart-snapshot` captures the active state plus bounded recent timeline,
+TODO, and pending-decision context. `restart-restore` selects the latest
+accessible snapshot when no ID is supplied; the service may synthesize one
+from current active state when no explicit snapshot exists. Select a specific
+snapshot or session only when needed:
+
+```text
+node scripts/xmemo-skill.mjs restart-snapshot --session_id handoff-a --timeline_limit 20
+node scripts/xmemo-skill.mjs restart-restore --source_session_id handoff-a --target_session_id handoff-b
+```
+
+All limits are client-validated against the hosted contract. Snapshot item
+limits accept `0..100`; `--ttl_seconds` accepts `0..2592000` (30 days).
+The direct REST responses can contain the captured continuity pack, so normal
+human output prints only status, ID, and time fields. Use `--json` only when a
+trusted caller needs the complete redacted response. Native MCP hosts should
+use `create_restart_snapshot` and `restore_restart_snapshot` instead of
+spawning the script.
 
 ### Add a TODO
 
@@ -180,4 +211,7 @@ runtime and `--timeout-ms <ms>` to bound each network request.
 - Responses larger than 8 MiB are rejected, and requests default to a 30-second
   timeout.
 - `save-state` / `restore-state` map to `update_state` / `_get_active_state_item` under the hood; they capture/resume server-side active task state.
+- `restart-snapshot` / `restart-restore` call `/v1/restart/snapshot` and
+  `/v1/restart/restore` directly and require a formal credential with memory
+  read/write access. Temporary agent credentials cannot use them.
 - Offline memory storage or local sync is not implemented.

--- a/skills/xmemo/references/troubleshooting.md
+++ b/skills/xmemo/references/troubleshooting.md
@@ -111,6 +111,8 @@ If this fails:
 | `No XMemo credential found` | Not logged in | Set `XMEMO_KEY`, or run `node scripts/xmemo-skill.mjs login --allow-plaintext` |
 | `Refusing unencrypted credential storage` | Missing explicit consent | Prefer `XMEMO_KEY`, or rerun the credential-writing command with `--allow-plaintext` |
 | `Authentication failed (HTTP 401)` | Token invalid/expired | Run `login` or add a new token |
+| `Restart snapshot not found` | The requested ID/session is unavailable in the current scope | Omit the selector to restore the latest accessible snapshot, or run `restart-snapshot` first |
+| Restart command reports temporary access | Temporary sandboxes expose only memory save/recall/search | Complete formal account claim/login, then retry |
 | `Remote XMemo server is not reachable` | Network or service outage | Check network/VPN/proxy |
 | `XMemo base URL must use HTTPS` | Insecure non-loopback service URL | Use HTTPS, or localhost HTTP only for local development |
 | `Request timed out` | Service/network exceeded the request deadline | Retry after checking service health, or set a bounded `--timeout-ms` |

--- a/skills/xmemo/references/troubleshooting.md
+++ b/skills/xmemo/references/troubleshooting.md
@@ -111,6 +111,7 @@ If this fails:
 | `No XMemo credential found` | Not logged in | Set `XMEMO_KEY`, or run `node scripts/xmemo-skill.mjs login --allow-plaintext` |
 | `Refusing unencrypted credential storage` | Missing explicit consent | Prefer `XMEMO_KEY`, or rerun the credential-writing command with `--allow-plaintext` |
 | `Authentication failed (HTTP 401)` | Token invalid/expired | Run `login` or add a new token |
+| Restart command is missing from `agent-discovery` operations | That list covers only the generic `/v1/skill/operations` dispatcher; restart continuity uses dedicated protected routes | Use the bundled Skill command with a formal credential; do not infer access from discovery alone or test by creating a real snapshot |
 | `Restart snapshot not found` | The requested ID/session is unavailable in the current scope | Omit the selector to restore the latest accessible snapshot, or run `restart-snapshot` first |
 | Restart command reports temporary access | Temporary sandboxes expose only memory save/recall/search | Complete formal account claim/login, then retry |
 | `Remote XMemo server is not reachable` | Network or service outage | Check network/VPN/proxy |

--- a/skills/xmemo/scripts/xmemo-skill.mjs
+++ b/skills/xmemo/scripts/xmemo-skill.mjs
@@ -13,7 +13,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 
-const SKILL_VERSION = '1.1.0';
+const SKILL_VERSION = '1.1.1';
 const credentialsPath = path.join(os.homedir(), '.xmemo', 'skill-credentials.json');
 const registrationPath = path.join(os.homedir(), '.xmemo', 'skill-registration.json');
 const SCRIPT_COMMAND = 'node scripts/xmemo-skill.mjs';
@@ -22,6 +22,7 @@ const DEFAULT_BASE_URL = 'https://xmemo.dev';
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_TIMEOUT_MS = 300_000;
 const MAX_RESPONSE_BYTES = 8_388_608;
+const MAX_STATE_TTL_SECONDS = 2_592_000;
 const DEFAULT_TEMPORARY_LIMITS = Object.freeze({
   max_items: 100,
   ttl_seconds: 1_209_600,
@@ -30,6 +31,7 @@ const DEFAULT_TEMPORARY_LIMITS = Object.freeze({
 const warnedCredentialOrigins = new Set();
 const REST_COMMANDS = new Set([
   'remember', 'recall', 'search', 'save-state', 'restore-state', 'state-save', 'state-restore',
+  'restart-snapshot', 'restart-restore',
   'todo-add', 'todo-list', 'todo-done', 'expense-add', 'doctor',
 ]);
 const COMMAND_FLAGS = {
@@ -44,6 +46,8 @@ const COMMAND_FLAGS = {
   'state-save': new Set(['key', 'state_key', 'content', 'current_task', 'next_action', 'blocked_reason', 'ttl_seconds', 'bucket', 'scope']),
   'restore-state': new Set(['key', 'state_key', 'bucket', 'scope']),
   'state-restore': new Set(['key', 'state_key', 'bucket', 'scope']),
+  'restart-snapshot': new Set(['session_id', 'state_key', 'timeline_limit', 'reminder_limit', 'decision_limit', 'metadata', 'bucket', 'scope', 'path', 'ttl_seconds']),
+  'restart-restore': new Set(['snapshot_id', 'source_session_id', 'target_session_id', 'state_key', 'restore_state', 'record_restore_event', 'ttl_seconds', 'bucket', 'scope']),
   'todo-add': new Set(['content', 'due_at', 'bucket', 'scope', 'path']),
   'todo-list': new Set(['bucket', 'scope', 'status']),
   'todo-done': new Set(['id', 'todo_id', 'note']),
@@ -186,6 +190,8 @@ function printUsage(command) {
       'restore-state': 'restore-state --key <key>',
       'state-save': 'state-save --key <key> [--content <text>] [--ttl_seconds <0..604800>] (legacy alias)',
       'state-restore': 'state-restore --key <key> (legacy alias)',
+      'restart-snapshot': 'restart-snapshot [--state_key <key>] [--session_id <id>] [--ttl_seconds <0..2592000>]',
+      'restart-restore': 'restart-restore [--snapshot_id <id> | --source_session_id <id>] [--target_session_id <id>]',
       'todo-add': 'todo-add --content <text>',
       'todo-list': 'todo-list',
       'todo-done': 'todo-done --id <todo_id>',
@@ -196,7 +202,7 @@ function printUsage(command) {
     return;
   }
 
-  console.log(`XMemo Standalone Skill Runtime\n\nUsage:\n  ${SCRIPT_COMMAND} <command> [options]\n\nCommands:\n  login --allow-plaintext            Start formal device login and explicitly permit local token storage\n  register --reason <unattended|declined> --allow-plaintext\n                                     Start limited temporary memory only when formal login is unavailable\n  logout                             Revoke and remove a local credential\n  auth status [--verify]             Show local or verified auth status\n  auth-status [--verify]             Alias for auth status\n  auth add --from-stdin --allow-plaintext\n                                     Store a formal token read from standard input\n  auth claim-status [--allow-plaintext]\n                                     Check temporary-account claim status\n  auth claim-confirm [--allow-plaintext]\n                                     Confirm a pending human claim and accept formal token handoff\n  auth claim-deny [--allow-plaintext]\n                                     Decline a pending bind and keep isolated temporary access\n  remember --content <text> --path <path>\n  recall --query <text> [--limit <n>] [--compact]\n  search --query <text> [--limit <n>] [--compact]\n  save-state --key <key> [--content <text>] (aliases: state-save)\n  restore-state --key <key> (aliases: state-restore)\n  todo-add --content <text>\n  todo-list\n  todo-done --id <todo_id>\n  expense-add --item <text> --amount <number> --currency <code>\n  doctor [--anonymous]\n\nCredential resolution:\n  XMEMO_KEY                          Preferred; never copied to the local credential file\n  User credential file              Read only as a fallback\n\nGlobal options:\n  --json                             Print the API response as JSON\n  --base-url <url>                   Override ${DEFAULT_BASE_URL}; HTTPS or loopback HTTP only\n  --timeout-ms <ms>                  Per-request timeout (default: ${DEFAULT_TIMEOUT_MS})\n  --compact                          Shorten recall/search content for terminals\n  --allow-plaintext                  Explicitly permit unencrypted user-file credential storage\n  --version                          Show the Skill runtime version\n  --help, -h                         Show this help\n\nRun \`${SCRIPT_COMMAND} <command> --help\` for command-specific usage.`);
+  console.log(`XMemo Standalone Skill Runtime\n\nUsage:\n  ${SCRIPT_COMMAND} <command> [options]\n\nCommands:\n  login --allow-plaintext            Start formal device login and explicitly permit local token storage\n  register --reason <unattended|declined> --allow-plaintext\n                                     Start limited temporary memory only when formal login is unavailable\n  logout                             Revoke and remove a local credential\n  auth status [--verify]             Show local or verified auth status\n  auth-status [--verify]             Alias for auth status\n  auth add --from-stdin --allow-plaintext\n                                     Store a formal token read from standard input\n  auth claim-status [--allow-plaintext]\n                                     Check temporary-account claim status\n  auth claim-confirm [--allow-plaintext]\n                                     Confirm a pending human claim and accept formal token handoff\n  auth claim-deny [--allow-plaintext]\n                                     Decline a pending bind and keep isolated temporary access\n  remember --content <text> --path <path>\n  recall --query <text> [--limit <n>] [--compact]\n  search --query <text> [--limit <n>] [--compact]\n  save-state --key <key> [--content <text>] (aliases: state-save)\n  restore-state --key <key> (aliases: state-restore)\n  restart-snapshot                  Save a full restart-continuity snapshot\n  restart-restore                   Restore the latest or selected restart snapshot\n  todo-add --content <text>\n  todo-list\n  todo-done --id <todo_id>\n  expense-add --item <text> --amount <number> --currency <code>\n  doctor [--anonymous]\n\nCredential resolution:\n  XMEMO_KEY                          Preferred; never copied to the local credential file\n  User credential file              Read only as a fallback\n\nGlobal options:\n  --json                             Print the API response as JSON\n  --base-url <url>                   Override ${DEFAULT_BASE_URL}; HTTPS or loopback HTTP only\n  --timeout-ms <ms>                  Per-request timeout (default: ${DEFAULT_TIMEOUT_MS})\n  --compact                          Shorten recall/search content for terminals\n  --allow-plaintext                  Explicitly permit unencrypted user-file credential storage\n  --version                          Show the Skill runtime version\n  --help, -h                         Show this help\n\nRun \`${SCRIPT_COMMAND} <command> --help\` for command-specific usage.`);
 }
 
 function parsePositiveInteger(value, name, max = Number.MAX_SAFE_INTEGER) {
@@ -306,10 +312,19 @@ function validateCommandInput(command, subcommand, positionals, options, flags) 
   }
 
   if (flags.limit !== undefined) parsePositiveInteger(flags.limit, '--limit', 100);
-  if (flags.ttl_seconds !== undefined) parseIntegerInRange(flags.ttl_seconds, '--ttl_seconds', 0, 604_800);
+  if (flags.ttl_seconds !== undefined) {
+    const ttlMax = command.startsWith('restart-') ? MAX_STATE_TTL_SECONDS : 604_800;
+    const parsedTtl = parseIntegerInRange(flags.ttl_seconds, '--ttl_seconds', 0, ttlMax);
+    if (command.startsWith('restart-')) flags.ttl_seconds = parsedTtl;
+  }
   if (flags.metadata !== undefined) flags.metadata = parseJsonObject(flags.metadata, '--metadata');
   if (flags.explain !== undefined) flags.explain = parseStrictBoolean(flags.explain, '--explain');
   if (flags.prefer_working !== undefined) flags.prefer_working = parseStrictBoolean(flags.prefer_working, '--prefer_working');
+  if (flags.restore_state !== undefined) flags.restore_state = parseStrictBoolean(flags.restore_state, '--restore_state');
+  if (flags.record_restore_event !== undefined) flags.record_restore_event = parseStrictBoolean(flags.record_restore_event, '--record_restore_event');
+  for (const key of ['timeline_limit', 'reminder_limit', 'decision_limit']) {
+    if (flags[key] !== undefined) flags[key] = parseIntegerInRange(flags[key], `--${key}`, 0, 100);
+  }
   if (flags.threshold !== undefined) {
     const threshold = Number(flags.threshold);
     if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
@@ -1077,7 +1092,7 @@ async function main() {
     process.exit(1);
   }
 
-  // 4. REST OPERATIONS (remember, recall, search, update, forget, state-save, state-restore, todo-*, expense-*, doctor)
+  // 4. REST OPERATIONS (memory, state, restart continuity, TODO, ledger, and diagnostics)
   const credential = command === 'doctor' && options.anonymous ? null : await getStoredCredential();
   const token = credential?.token;
   
@@ -1123,6 +1138,35 @@ async function main() {
     }
     console.error(`Temporary access supports only remember, recall, and search in its isolated sandbox. Complete formal registration at ${sanitizeTerminalText(credential.bind_url || 'the bind URL shown at registration')} to use ${command}.`);
     process.exit(1);
+  }
+
+  if (command === 'restart-snapshot' || command === 'restart-restore') {
+    const endpoint = command === 'restart-snapshot' ? '/v1/restart/snapshot' : '/v1/restart/restore';
+    const label = command === 'restart-snapshot' ? 'Restart snapshot' : 'Restart restore';
+    try {
+      const res = await makeHttpRequest(options.baseUrl, endpoint, 'POST', flags, {
+        'Authorization': `Bearer ${token}`
+      }, options.timeoutMs);
+      const data = parseJsonResponse(res, `${label} request`);
+      const succeeded = res.statusCode >= 200 && res.statusCode < 300;
+      if (options.json) {
+        console.log(safeJson(data));
+        process.exit(succeeded ? 0 : 1);
+      }
+      if (!succeeded) {
+        console.error(`${label} failed: ${apiErrorMessage(data)} (HTTP ${res.statusCode})`);
+        process.exit(1);
+      }
+      if (command === 'restart-snapshot') {
+        console.log(`✅ Restart snapshot saved.\nID: ${sanitizeTerminalText(extractId(data))}${data.expires_at ? `\nExpires: ${sanitizeTerminalText(data.expires_at)}` : ''}`);
+      } else {
+        console.log(`✅ Restart snapshot restored.\nID: ${sanitizeTerminalText(extractId(data))}${data.restored_at ? `\nRestored: ${sanitizeTerminalText(data.restored_at)}` : ''}`);
+      }
+    } catch (e) {
+      console.error(`${label} failed:`, e.message);
+      process.exit(1);
+    }
+    return;
   }
 
   // Normalize commands for operations mapping

--- a/skills/xmemo/scripts/xmemo-skill.mjs
+++ b/skills/xmemo/scripts/xmemo-skill.mjs
@@ -13,7 +13,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 
-const SKILL_VERSION = '1.1.1';
+const SKILL_VERSION = '1.1.2';
 const credentialsPath = path.join(os.homedir(), '.xmemo', 'skill-credentials.json');
 const registrationPath = path.join(os.homedir(), '.xmemo', 'skill-registration.json');
 const SCRIPT_COMMAND = 'node scripts/xmemo-skill.mjs';

--- a/src/mcp/stdio-server.js
+++ b/src/mcp/stdio-server.js
@@ -19,12 +19,12 @@ const STATIC_TOOL_DESCRIPTIONS = {
   get_mcp_identity: 'Check XMemo connection status and the connected account/agent.',
   remember: 'Save a memory so it can be recalled in future conversations.',
   recall: 'Recall the most relevant saved memories before answering.',
-  recall_context: 'Build a context pack from XMemo memories for complex tasks.',
+  recall_context: 'Read a multi-memory context pack. Requires memory:read and does not change content. Use when many memories need explicit budgets; use recall for lightweight answer or get_project_context for project snapshot. max_items/max_tokens bound rendered output.',
   memory_stats: 'Show aggregate statistics for XMemo memories.',
   update_memory: 'Update the content or metadata of an existing memory.',
   explain_memory: 'Explain why a memory exists or matched a query.',
   restore_memory: 'Restore a previously deleted memory.',
-  add_expense: 'Record one expense in the XMemo Ledger.',
+  add_expense: "Create one XMemo Ledger transaction and backing memory. Requires memory:write; it records a new transaction or reuses a semantic duplicate, and never deletes Ledger records. Use it for a purchase, income, refund, or transfer; use list_ledger_transactions or get_monthly_ledger_summary for reads. amount must be positive; transaction_type defaults to expense; blank transaction_date uses today's UTC date.",
   list_ledger_transactions: 'Show XMemo Ledger records.',
   get_monthly_ledger_summary: 'Summarize Ledger totals by month and currency.',
   forget: 'Permanently delete a memory by target.',
@@ -32,10 +32,10 @@ const STATIC_TOOL_DESCRIPTIONS = {
   list_memory_todos: 'List open or completed TODO/action items.',
   complete_memory_todo: 'Mark a TODO/action item completed.',
   list_memory_versions: 'List available versions for a memory.',
-  get_timeline: 'Show recent timeline events.',
+  get_timeline: 'Read authorized timeline events newest first. Requires memory:read and makes no memory changes. Use it for recent history or session resumption; use recall_context for semantic multi-memory context. limit is clamped to 1-500; session_id and event_type are exact filters.',
   record_event: 'Record a significant session event, milestone, or decision.',
-  update_state: 'Save the current working state during long-running work.',
-  get_project_context: 'Build project-scoped context from XMemo memories.'
+  update_state: 'Create or replace one scoped working-state record for resuming a task, next action, or blocker. Requires memory:write; it versions that state slot and refreshes its expiry without deleting other memories. Use remember for durable facts or record_event for history. Provide content or a structured state field; ttl_seconds=0 means no expiry.',
+  get_project_context: "Read one authorized project's bounded context pack: state, TODOs, decisions, timeline, recent memories, and optional durable recall. Requires memory:read; it does not mutate project memories, and access is audit-logged. Use an exact project_id for a whole-project snapshot; otherwise use recall_context. max_items/max_tokens bound the whole pack; recent_hours affects only timeline; durable_query requires include_durable_context."
 };
 
 const STATIC_TOOL_SCHEMAS = {
@@ -47,7 +47,19 @@ const STATIC_TOOL_SCHEMAS = {
     query: { type: 'string', description: 'Natural-language question or search text.' }
   },
   recall_context: {
-    query: { type: 'string', description: 'Natural-language question or search text.' }
+    query: { type: 'string', description: 'Natural-language query used to rank memories for the context pack.' },
+    max_items: { type: 'integer', default: 8, description: 'Maximum memories rendered in the context pack.' },
+    max_tokens: { type: 'integer', default: 1500, description: 'Approximate token budget for the rendered context pack.' },
+    limit: { type: 'integer', default: 0, description: 'Candidate-result limit; 0 derives it from the item/token budgets.' },
+    path_filter: { type: 'string', default: '%', description: 'Case-insensitive memory-path pattern; % matches all paths.' },
+    bucket: { type: 'string', default: '%', description: 'Accessible bucket filter; % includes all accessible buckets.' },
+    scope: { type: 'string', default: '', description: 'Optional authorized scope; blank uses the token default.' },
+    team_id: { type: 'string', default: '', description: 'Optional exact authorized team filter.' },
+    memory_type: { type: 'string', default: 'auto', description: 'Memory type filter; auto searches the normal mixed set.' },
+    prefer_working: { type: 'boolean', default: true, description: 'True prioritizes active working/session-state signals.' },
+    output_json: { type: 'boolean', default: false, description: 'True returns the full structured pack; false returns rendered context text.' },
+    agent_id: { type: 'string', default: '', description: 'Optional client-supplied agent label for memory attribution.' },
+    agent_instance_id: { type: 'string', default: '', description: 'Optional stable, non-secret agent instance ID for per-client attribution.' }
   },
   update_memory: {
     memory_id: { type: 'string', description: 'Exact XMemo memory reference.' },
@@ -63,8 +75,24 @@ const STATIC_TOOL_SCHEMAS = {
     reason: { type: 'string', description: 'Optional restore reason.' }
   },
   add_expense: {
-    item: { type: 'string', description: 'The purchased item or service.' },
-    amount: { type: 'number', description: 'Positive transaction amount.' }
+    item: { type: 'string', description: 'Purchased item, income source, refund, or transfer label.' },
+    amount: { type: 'number', description: 'Positive transaction amount; zero and negative values are rejected.' },
+    transaction_type: { type: 'string', default: 'expense', description: 'Transaction to create: expense, income, refund, or transfer.' },
+    currency: { type: 'string', default: 'CNY', description: 'Currency code or label; labels such as yen or RMB are normalized to codes.' },
+    transaction_date: { type: 'string', default: '', description: "YYYY-MM-DD transaction date; blank uses today's UTC date." },
+    category: { type: 'string', default: '', description: 'Optional Ledger category, such as food, transport, or electronics.' },
+    merchant: { type: 'string', default: '', description: 'Optional merchant, payer, payee, or store name.' },
+    payment_method: { type: 'string', default: '', description: 'Optional payment method, such as card, cash, Alipay, or WeChat Pay.' },
+    note: { type: 'string', default: '', description: 'Optional note stored with the transaction.' },
+    path: { type: 'string', default: 'finance/ledger/expenses', description: 'Memory path; the default follows transaction_type for non-expenses.' },
+    bucket: { type: 'string', default: 'private', description: 'Bucket for the backing memory; defaults to private.' },
+    scope: { type: 'string', default: '', description: 'Optional authorized scope; must match project_id when both are set.' },
+    team_id: { type: 'string', default: '', description: 'Optional team attribution within the authorized scope.' },
+    agent_id: { type: 'string', default: '', description: 'Optional client-supplied agent label for memory attribution.' },
+    agent_instance_id: { type: 'string', default: '', description: 'Optional stable, non-secret agent instance ID for per-client attribution.' },
+    device_id: { type: 'string', default: '', description: 'Optional client-supplied device identifier for attribution.' },
+    device_label: { type: 'string', default: '', description: 'Optional human-readable device label for attribution.' },
+    project_id: { type: 'string', default: '', description: 'Optional exact authorized project ID; stores the transaction in its private scope.' }
   },
   list_ledger_transactions: {
     query: { type: 'string', description: 'Optional ledger search text.' },
@@ -94,14 +122,36 @@ const STATIC_TOOL_SCHEMAS = {
   record_event: {
     content: { type: 'string', description: 'Text body of the event.' }
   },
+  get_timeline: {
+    limit: { type: 'integer', default: 20, description: 'Maximum events to return; values are clamped to 1-500.' },
+    bucket: { type: 'string', default: '%', description: 'Accessible bucket filter; % includes all accessible buckets.' },
+    scope: { type: 'string', default: '', description: 'Optional authorized scope; blank uses the token default.' },
+    session_id: { type: 'string', default: '', description: 'Optional exact session ID filter.' },
+    event_type: { type: 'string', default: '', description: 'Optional exact event type after lowercase normalization.' }
+  },
   update_state: {
-    state_key: { type: 'string', description: 'Working-state key to save.' },
-    current_task: { type: 'string', description: 'Current task or work item.' },
-    next_action: { type: 'string', description: 'Next action for later resume.' }
+    content: { type: 'string', default: '', description: 'Free-form state body; otherwise provide at least one structured state field.' },
+    state_key: { type: 'string', default: 'active_task', description: 'Normalized state slot; the same owner, bucket, scope, and key updates that slot.' },
+    current_task: { type: 'string', default: '', description: 'Current task; used to build the state body when content is blank.' },
+    next_action: { type: 'string', default: '', description: 'Next action; used to build the state body when content is blank.' },
+    blocked_reason: { type: 'string', default: '', description: 'Blocker; used to build the state body when content is blank.' },
+    metadata_json: { type: 'string', default: '{}', description: 'JSON object merged into the working-state metadata.' },
+    ttl_seconds: { type: 'integer', default: 86400, description: 'Expiry in seconds from 0 to 2592000; 0 means no expiry.' },
+    bucket: { type: 'string', default: 'work', description: 'Bucket containing the working-state slot; defaults to work.' },
+    scope: { type: 'string', default: '', description: 'Scope containing the working-state slot; blank uses the token default.' }
   },
   get_project_context: {
-    query: { type: 'string', description: 'Project-context query.' },
-    project_id: { type: 'string', description: 'Optional project identifier.' }
+    project_id: { type: 'string', description: 'Exact authorized project ID; project names are not accepted.' },
+    bucket: { type: 'string', default: '%', description: 'Accessible bucket filter; % includes all accessible buckets.' },
+    team_id: { type: 'string', default: '', description: 'Optional exact authorized team focus; other team rows are excluded.' },
+    max_items: { type: 'integer', default: 100, description: 'Whole-pack item budget from 1 to 1000.' },
+    max_tokens: { type: 'integer', default: 8000, description: 'Whole-pack approximate token budget from 1 to 50000.' },
+    include_durable_context: { type: 'boolean', default: true, description: 'Include semantic durable recall; false omits that section.' },
+    durable_query: { type: 'string', default: '', description: 'Query only for durable recall; ignored when include_durable_context is false.' },
+    recent_hours: { type: 'integer', default: 168, description: 'Timeline lookback from 1 to 8760 hours; other sections are unaffected.' },
+    output_json: { type: 'boolean', default: false, description: 'True returns the full structured pack; false returns a text summary.' },
+    agent_id: { type: 'string', default: '', description: 'Optional client-supplied agent label for memory attribution.' },
+    agent_instance_id: { type: 'string', default: '', description: 'Optional stable, non-secret agent instance ID for per-client attribution.' }
   }
 };
 
@@ -117,7 +167,14 @@ const STATIC_TOOL_REQUIRED = {
   complete_memory_todo: ['todo_id'],
   list_memory_versions: ['memory_id'],
   record_event: ['content'],
+  get_project_context: ['project_id'],
 };
+
+const READ_ONLY_STATIC_TOOLS = new Set([
+  'recall_context',
+  'get_project_context',
+  'get_timeline'
+]);
 
 const STATIC_TOOL_NAMES = [
   'get_mcp_identity',
@@ -149,7 +206,24 @@ export const STATIC_TOOLS = STATIC_TOOL_NAMES.map((name) => ({
     type: 'object',
     properties: STATIC_TOOL_SCHEMAS[name] || {},
     required: STATIC_TOOL_REQUIRED[name] || []
-  }
+  },
+  outputSchema: {
+    type: 'object',
+    properties: {
+      result: { type: 'string', description: 'Human-readable text or JSON requested by output_json.' }
+    },
+    required: ['result']
+  },
+  ...(READ_ONLY_STATIC_TOOLS.has(name) || name === 'update_state' || name === 'add_expense'
+    ? {
+        annotations: {
+          readOnlyHint: READ_ONLY_STATIC_TOOLS.has(name),
+          destructiveHint: false,
+          idempotentHint: READ_ONLY_STATIC_TOOLS.has(name),
+          openWorldHint: false
+        }
+      }
+    : {})
 }));
 
 const SERVER_INFO = {

--- a/test/mcp-stdio.test.js
+++ b/test/mcp-stdio.test.js
@@ -44,6 +44,45 @@ test('offline stdio tools/list exposes current full/free XMemo tools', async () 
   assert.equal(names.includes('query_audit'), false);
   assert.equal(names.includes('update_project_todo'), false);
   assert.equal(names.includes('update_project_decision'), false);
+
+  const tools = new Map(response.result.tools.map((tool) => [tool.name, tool]));
+  const qualityTargets = {
+    recall_context: {
+      parameterCount: 13,
+      markers: ['Requires memory:read', 'use recall for lightweight answer', 'get_project_context']
+    },
+    add_expense: {
+      parameterCount: 18,
+      markers: ['Requires memory:write', 'never deletes Ledger records', 'list_ledger_transactions']
+    },
+    get_timeline: {
+      parameterCount: 5,
+      markers: ['events newest first', 'Requires memory:read', 'use recall_context']
+    },
+    update_state: {
+      parameterCount: 9,
+      markers: ['Requires memory:write', 'Use remember for durable facts', 'ttl_seconds=0']
+    },
+    get_project_context: {
+      parameterCount: 11,
+      markers: ['Requires memory:read', 'exact project_id', 'otherwise use recall_context']
+    }
+  };
+
+  for (const [name, expected] of Object.entries(qualityTargets)) {
+    const tool = tools.get(name);
+    assert.ok(tool, name);
+    assert.equal(Object.keys(tool.inputSchema.properties).length, expected.parameterCount, name);
+    for (const marker of expected.markers) {
+      assert.match(tool.description, new RegExp(escapeRegExp(marker)), `${name}: ${marker}`);
+    }
+    for (const property of Object.values(tool.inputSchema.properties)) {
+      assert.doesNotMatch(property.description, /Input value for/i, name);
+    }
+    assert.equal(tool.outputSchema.required.includes('result'), true, name);
+    assert.equal(tool.annotations.destructiveHint, false, name);
+  }
+  assert.deepEqual(tools.get('get_project_context').inputSchema.required, ['project_id']);
 });
 
 test('offline stdio initialize advertises tools, prompts, and resources', async () => {
@@ -155,4 +194,8 @@ async function callStdio(requests) {
   const lines = stdout.trim().split(/\r?\n/).filter(Boolean);
   assert.equal(lines.length, requests.length, stdout);
   return lines.map((line) => JSON.parse(line));
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/test/xmemo-skill.test.js
+++ b/test/xmemo-skill.test.js
@@ -9,6 +9,7 @@ const packageJson = JSON.parse(await readFile(path.join(repoRoot, 'package.json'
 
 test('XMemo Skill describes standalone CLI-backed runtime selection', async () => {
   const skill = (await readFile(path.join(repoRoot, 'skills/xmemo/SKILL.md'), 'utf8')).replace(/\r\n/g, '\n');
+  const operations = (await readFile(path.join(repoRoot, 'skills/xmemo/references/operations.md'), 'utf8')).replace(/\r\n/g, '\n');
 
   assert.match(skill, /^---\nname: xmemo-memory\ndescription: .+\n---\n/);
   assert.match(skill, /Runtime Selection/);
@@ -26,6 +27,10 @@ test('XMemo Skill describes standalone CLI-backed runtime selection', async () =
   assert.match(skill, /restore-state/);
   assert.match(skill, /restart-snapshot/);
   assert.match(skill, /restart-restore/);
+  assert.match(skill, /Hosted Discovery Boundary/);
+  assert.match(skill, /standalone_skill\.operations/);
+  assert.match(skill, /\/v1\/restart\/snapshot/);
+  assert.match(skill, /temporary-agent manifest/i);
   assert.match(skill, /create_restart_snapshot/);
   assert.match(skill, /restore_restart_snapshot/);
   assert.match(skill, /todo-add/);
@@ -47,6 +52,9 @@ test('XMemo Skill describes standalone CLI-backed runtime selection', async () =
   assert.match(skill, /references\/troubleshooting\.md/);
   assert.match(skill, /Do not simulate a successful memory read or write/i);
   assert.doesNotMatch(skill, /mos_[A-Za-z0-9_-]+:r-[A-Za-z0-9_-]+/);
+  assert.match(operations, /## Discovery boundary/);
+  assert.match(operations, /generic `POST \/v1\/skill\/operations` dispatcher/);
+  assert.match(operations, /unauthenticated `401` only\nproves that the protected route is reachable/);
 });
 
 test('npm package includes the XMemo Skill, script, and references', async () => {

--- a/test/xmemo-skill.test.js
+++ b/test/xmemo-skill.test.js
@@ -24,6 +24,10 @@ test('XMemo Skill describes standalone CLI-backed runtime selection', async () =
   assert.match(skill, /search/);
   assert.match(skill, /save-state/);
   assert.match(skill, /restore-state/);
+  assert.match(skill, /restart-snapshot/);
+  assert.match(skill, /restart-restore/);
+  assert.match(skill, /create_restart_snapshot/);
+  assert.match(skill, /restore_restart_snapshot/);
   assert.match(skill, /todo-add/);
   assert.match(skill, /expense-add/);
   assert.match(skill, /--compact/);

--- a/test/xmemo-standalone-skill.test.js
+++ b/test/xmemo-standalone-skill.test.js
@@ -304,9 +304,13 @@ test('skill script exposes usage and preserves non-JSON server diagnostics', asy
   assert.match(loginHelp.stdout, /login --allow-plaintext/);
   assert.doesNotMatch(loginHelp.stdout, /Commands:/);
 
+  const changelog = await fs.readFile(path.join(repoRoot, 'skills/xmemo/CHANGELOG.md'), 'utf8');
+  const latestRelease = changelog.match(/^##\s*(\d+\.\d+\.\d+)\s*$/m)?.[1];
+  assert.match(latestRelease ?? '', /^\d+\.\d+\.\d+$/);
+
   const versionRes = await runScript(['--version']);
   assert.equal(versionRes.code, 0);
-  assert.match(versionRes.stdout, /^1\.1\.0\s*$/);
+  assert.equal(versionRes.stdout.trim(), latestRelease);
 
   const unknownRes = await runScript(['not-a-command']);
   assert.notEqual(unknownRes.code, 0);
@@ -854,6 +858,83 @@ test('skill script state-save and state-restore commands', async () => {
   assert.match(restoreRes.stdout, /running tests/);
 
   await testServer.stop();
+});
+
+test('skill script creates and restores full restart-continuity snapshots', async () => {
+  const testServer = createTestServer();
+  const baseUrl = await testServer.start();
+  const env = { XMEMO_KEY: 'secret-token-key' };
+
+  try {
+    testServer.setResponse({
+      id: 'restart_123',
+      memory_id: 'memory_123',
+      status: 'created',
+      expires_at: '2026-08-10T00:00:00Z',
+      snapshot: { active_state: { content: 'must stay out of normal output' } },
+    }, 201);
+    const snapshot = await runScript([
+      'restart-snapshot',
+      '--session_id', 'handoff-a',
+      '--timeline_limit', '10',
+      '--reminder_limit', '5',
+      '--decision_limit', '0',
+      '--ttl_seconds', '2592000',
+      '--metadata', '{"source":"skill-test"}',
+      '--scope', 'project-demo',
+    ], { baseUrl, env });
+
+    assert.equal(snapshot.code, 0);
+    assert.match(snapshot.stdout, /Restart snapshot saved/);
+    assert.match(snapshot.stdout, /restart_123/);
+    assert.doesNotMatch(snapshot.stdout, /must stay out of normal output/);
+    assert.equal(testServer.requests.at(-1).url, '/v1/restart/snapshot');
+    assert.equal(testServer.requests.at(-1).headers.authorization, 'Bearer secret-token-key');
+    assert.deepEqual(testServer.requests.at(-1).body, {
+      session_id: 'handoff-a',
+      timeline_limit: 10,
+      reminder_limit: 5,
+      decision_limit: 0,
+      ttl_seconds: 2592000,
+      metadata: { source: 'skill-test' },
+      scope: 'project-demo',
+    });
+
+    testServer.setResponse({
+      id: 'restart_123',
+      memory_id: 'memory_123',
+      status: 'restored',
+      restored_at: '2026-08-03T00:00:00Z',
+      snapshot: {},
+      state_update: null,
+      restore_event: null,
+    });
+    const restore = await runScript([
+      'restart-restore',
+      '--source_session_id', 'handoff-a',
+      '--target_session_id', 'handoff-b',
+      '--restore_state', 'true',
+      '--record_restore_event', 'false',
+    ], { baseUrl, env });
+
+    assert.equal(restore.code, 0);
+    assert.match(restore.stdout, /Restart snapshot restored/);
+    assert.equal(testServer.requests.at(-1).url, '/v1/restart/restore');
+    assert.deepEqual(testServer.requests.at(-1).body, {
+      source_session_id: 'handoff-a',
+      target_session_id: 'handoff-b',
+      restore_state: true,
+      record_restore_event: false,
+    });
+
+    const invalidLimit = await runScript([
+      'restart-snapshot', '--timeline_limit', '101',
+    ], { baseUrl, env });
+    assert.notEqual(invalidLimit.code, 0);
+    assert.match(invalidLimit.stderr, /--timeline_limit must be between 0 and 100/);
+  } finally {
+    await testServer.stop();
+  }
 });
 
 test('skill script expense-add command calls /v1/skill/operations with operation expense-add', async () => {


### PR DESCRIPTION
## Summary

- publish the source baseline corresponding to the already-live ClawHub XMemo Skill 1.1.2
- add standalone restart snapshot/restore continuity and focused regression coverage
- clarify the hosted discovery boundary and synchronize @xmemo/client release metadata at 0.4.180

## Validation

- `npm run release:check`
- `npm run lint`
- `node --test test/mcp-stdio.test.js test/xmemo-skill.test.js test/xmemo-standalone-skill.test.js` (31 passed)
- `npm run pack:dry-run`

## Release boundary

ClawHub 1.1.2 is already published and CLEAN. This PR only reconciles public source provenance; it does not publish ClawHub or npm.