### PR TITLE
fix(skill): clarify empty state restore

### DIFF
--- a/skills/xmemo/CHANGELOG.md
+++ b/skills/xmemo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # XMemo Skill Change Log
 
+## 1.1.3
+
+- `scripts/xmemo-skill.mjs`: report a clear empty-state result when a successful
+  `restore-state` response contains no saved state, while preserving the
+  requested key and an explicit empty-content marker for valid state objects.
+- Tests: cover empty and partially populated state-restore responses so the
+  standalone command does not print `undefined` to users.
+
 ## 1.1.2
 
 - `SKILL.md` and references: distinguish the public generic

--- a/skills/xmemo/scripts/xmemo-skill.mjs
+++ b/skills/xmemo/scripts/xmemo-skill.mjs
@@ -13,7 +13,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 
-const SKILL_VERSION = '1.1.2';
+const SKILL_VERSION = '1.1.3';
 const credentialsPath = path.join(os.homedir(), '.xmemo', 'skill-credentials.json');
 const registrationPath = path.join(os.homedir(), '.xmemo', 'skill-registration.json');
 const SCRIPT_COMMAND = 'node scripts/xmemo-skill.mjs';
@@ -1223,7 +1223,16 @@ async function main() {
         });
       }
     } else if (opName === 'state-restore') {
-      console.log(`Working State restored:\nKey: ${sanitizeTerminalText(data.result?.state_key)}\nContent: ${formatMemoryContent(data.result?.content, false)}`);
+      const state = data.result;
+      if (!state || typeof state !== 'object') {
+        console.log('No saved working state found for the requested key.');
+      } else {
+        const stateKey = state.state_key || flags.key || flags.state_key || '(unknown)';
+        const content = state.content === undefined || state.content === null || state.content === ''
+          ? '(empty)'
+          : state.content;
+        console.log(`Working State restored:\nKey: ${sanitizeTerminalText(stateKey)}\nContent: ${formatMemoryContent(content, false)}`);
+      }
     } else if (opName === 'remember') {
       console.log(`✅ Saved to XMemo.\nID: ${sanitizeTerminalText(extractId(data.result))}`);
     } else if (opName === 'expense-add') {

--- a/test/xmemo-standalone-skill.test.js
+++ b/test/xmemo-standalone-skill.test.js
@@ -860,6 +860,29 @@ test('skill script state-save and state-restore commands', async () => {
   await testServer.stop();
 });
 
+test('skill script renders empty and partial state-restore results clearly', async () => {
+  const testServer = createTestServer();
+  const baseUrl = await testServer.start();
+  const env = { XMEMO_KEY: 'secret-token-key' };
+
+  try {
+    testServer.setResponse({ ok: true, operation: 'state-restore', result: null });
+    const missing = await runScript(['restore-state', '--key', 'active_task'], { baseUrl, env });
+    assert.equal(missing.code, 0);
+    assert.match(missing.stdout, /No saved working state found/);
+    assert.doesNotMatch(missing.stdout, /undefined/);
+
+    testServer.setResponse({ ok: true, operation: 'state-restore', result: { content: '' } });
+    const partial = await runScript(['restore-state', '--key', 'active_task'], { baseUrl, env });
+    assert.equal(partial.code, 0);
+    assert.match(partial.stdout, /Key: active_task/);
+    assert.match(partial.stdout, /Content: \(empty\)/);
+    assert.doesNotMatch(partial.stdout, /undefined/);
+  } finally {
+    await testServer.stop();
+  }
+});
+
 test('skill script creates and restores full restart-continuity snapshots', async () => {
   const testServer = createTestServer();
   const baseUrl = await testServer.start();


### PR DESCRIPTION
## Summary
- Clarify standalone `restore-state` output when the service returns no saved state or an empty payload.
- Bump the standalone Skill runtime and changelog from `1.1.2` to `1.1.3`.

## Baseline evidence
- ClawHub latest: `1.1.2` (clean moderation; manifest matched, with only managed `skill-card.md` online).
- Public `origin/main`: `1.1.2`, commit `3a0cf8c`.
- No open baseline or automation PRs at inspection.

## Validation
- `verify-candidate.mjs`: passed; `baseVersion=1.1.2`, `onlineVersion=1.1.2`, `candidateVersion=1.1.3`; 3 changed files, 42 added lines.
- `npm run lint`: passed.
- `node --test test/xmemo-skill.test.js test/xmemo-standalone-skill.test.js`: passed (28/28).
- `npm run pack:dry-run`: passed.

## Risk boundary
Only `skills/xmemo/**` and its focused standalone test changed. No service/API/auth/scope/deletion/privacy/retention/dependency/package metadata changes.

Phase B: no merge or publish.