### PR TITLE
feat(skill): add doctor discovery diagnostics

### DIFF
--- a/skills/xmemo/CHANGELOG.md
+++ b/skills/xmemo/CHANGELOG.md
@@ -1,5 +1,17 @@
 # XMemo Skill Change Log
 
+## 1.1.4
+
+- `scripts/xmemo-skill.mjs`: add a bounded, token-free `clientDiagnostics`
+  block to `doctor --json`, including read-only discovery service/capability
+  summary and a concrete next credential-check or sign-in command.
+- Diagnostics: when discovery is unavailable, report a stable degraded status
+  without failing an otherwise healthy doctor operation or changing any auth,
+  write, or restart-continuity behavior.
+- Tests and Skill documentation: cover authenticated, anonymous, and degraded
+  discovery output while preserving the no-Authorization-header guarantee for
+  `doctor --anonymous`.
+
 ## 1.1.3
 
 - `scripts/xmemo-skill.mjs`: report a clear empty-state result when a successful

--- a/skills/xmemo/SKILL.md
+++ b/skills/xmemo/SKILL.md
@@ -126,7 +126,11 @@ node scripts/xmemo-skill.mjs register --reason <unattended|declined> --allow-pla
 
 The script supports JSON output with `--json`, command-specific usage with
 `--help`, `--version`, per-request timeouts with `--timeout-ms`, and compact
-recall/search output with `--compact`. It never prints token values or prefixes.
+recall/search output with `--compact`. `doctor --json` adds a bounded
+`clientDiagnostics` object: a read-only discovery summary and a `nextAction`
+command for the next credential check or formal sign-in. If discovery is
+unavailable, `clientDiagnostics.discovery.status` is `unavailable`; a successful
+doctor health check still succeeds. It never prints token values or prefixes.
 
 When native XMemo MCP tools are present, use `create_restart_snapshot` and
 `restore_restart_snapshot` for the same full-continuity workflow. The bundled
@@ -168,7 +172,9 @@ node scripts/xmemo-skill.mjs auth claim-status
 
 `doctor` retains authenticated diagnosis when a credential is available.
 `doctor --anonymous` performs the same service-health check without sending an
-Authorization header.
+Authorization header. Both forms use only an unauthenticated, read-only
+discovery request for their JSON capability summary; discovery failure does not
+block an otherwise successful health check.
 
 For detailed examples, read `references/operations.md`. For auth, network, and service diagnosis, read `references/troubleshooting.md`.
 

--- a/skills/xmemo/scripts/xmemo-skill.mjs
+++ b/skills/xmemo/scripts/xmemo-skill.mjs
@@ -13,7 +13,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 
-const SKILL_VERSION = '1.1.3';
+const SKILL_VERSION = '1.1.4';
 const credentialsPath = path.join(os.homedir(), '.xmemo', 'skill-credentials.json');
 const registrationPath = path.join(os.homedir(), '.xmemo', 'skill-registration.json');
 const SCRIPT_COMMAND = 'node scripts/xmemo-skill.mjs';
@@ -406,6 +406,93 @@ function formatDuration(seconds) {
   if (seconds % 86_400 === 0) return `${seconds / 86_400} days`;
   if (seconds % 3_600 === 0) return `${seconds / 3_600} hours`;
   return `${seconds} seconds`;
+}
+
+function discoveryString(value) {
+  if (typeof value !== 'string') return null;
+  const sanitized = sanitizeTerminalText(value).trim();
+  return sanitized ? sanitized.slice(0, 200) : null;
+}
+
+function discoveryStringList(value, maxItems = 24) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item) => typeof item === 'string')
+    .map(discoveryString)
+    .filter(Boolean)
+    .slice(0, maxItems);
+}
+
+function summarizeDoctorDiscovery(discovery, discoveryUrl) {
+  const standalone = discovery?.standalone_skill ?? discovery?.integrations?.standalone_skill ?? {};
+  return {
+    status: 'available',
+    url: discoveryUrl,
+    schemaVersion: discoveryString(discovery?.schema_version),
+    protocol: discoveryString(discovery?.protocol),
+    service: discoveryString(discovery?.service),
+    standaloneSkill: {
+      status: discoveryString(standalone.status),
+      runtimeModel: discoveryString(standalone.runtime_model),
+      operations: discoveryStringList(standalone.operations),
+      defaultScopes: discoveryStringList(standalone.auth?.default_scopes),
+    },
+  };
+}
+
+function discoveryFailureCode(error) {
+  const message = String(error?.message ?? '').toLowerCase();
+  if (message.includes('timed out')) return 'timeout';
+  if (message.includes('non-json')) return 'invalid_response';
+  return 'request_failed';
+}
+
+async function fetchDoctorDiscovery(baseUrl, timeoutMs) {
+  const discoveryUrl = new URL('/.well-known/agent-discovery.json', baseUrl).toString();
+  try {
+    const res = await makeHttpRequest(baseUrl, '/.well-known/agent-discovery.json', 'GET', null, {}, timeoutMs);
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      return {
+        status: 'unavailable',
+        url: discoveryUrl,
+        errorCode: 'http_error',
+        httpStatus: res.statusCode ?? null,
+      };
+    }
+    return summarizeDoctorDiscovery(parseJsonResponse(res, 'Doctor discovery'), discoveryUrl);
+  } catch (error) {
+    return {
+      status: 'unavailable',
+      url: discoveryUrl,
+      errorCode: discoveryFailureCode(error),
+    };
+  }
+}
+
+function doctorNextAction({ credential, anonymous }) {
+  if (!anonymous && !credential) {
+    return {
+      command: `${SCRIPT_COMMAND} login --allow-plaintext`,
+      reason: 'Sign in before using account-scoped memory operations.',
+    };
+  }
+  return {
+    command: `${SCRIPT_COMMAND} auth status --verify`,
+    reason: 'Verify the credential separately when an authenticated follow-up is needed.',
+  };
+}
+
+function withDoctorDiagnostics(data, discovery, nextAction) {
+  const report = data && typeof data === 'object' && !Array.isArray(data)
+    ? { ...data }
+    : { ok: true, result: data };
+  return {
+    ...report,
+    clientDiagnostics: {
+      discovery,
+      nextAction,
+    },
+  };
 }
 
 // HTTP request helper
@@ -1099,6 +1186,9 @@ async function main() {
   // Doctor can be anonymous
   if (command === 'doctor' && !token) {
     try {
+      const discovery = options.json
+        ? await fetchDoctorDiscovery(options.baseUrl, options.timeoutMs)
+        : null;
       const res = await makeHttpRequest(options.baseUrl, '/v1/skill/operations', 'POST', {
         operation: 'doctor',
         arguments: {}
@@ -1109,7 +1199,10 @@ async function main() {
         process.exit(1);
       }
       if (options.json) {
-        console.log(safeJson(data));
+        console.log(safeJson(withDoctorDiagnostics(data, discovery, doctorNextAction({
+          credential,
+          anonymous: options.anonymous,
+        }))));
       } else {
         console.log(`XMemo Service Status: OK\nAuthentication: Missing/Unauthenticated`);
       }
@@ -1175,6 +1268,9 @@ async function main() {
   if (command === 'restore-state' || command === 'state-restore') opName = 'state-restore';
 
   try {
+    const discovery = command === 'doctor' && options.json
+      ? await fetchDoctorDiscovery(options.baseUrl, options.timeoutMs)
+      : null;
     const res = await makeHttpRequest(options.baseUrl, '/v1/skill/operations', 'POST', {
       operation: opName,
       arguments: flags,
@@ -1185,7 +1281,10 @@ async function main() {
     const data = parseJsonResponse(res, `${opName} request`);
     const succeeded = res.statusCode >= 200 && res.statusCode < 300 && data.ok !== false;
     if (options.json) {
-      console.log(safeJson(data));
+      const output = opName === 'doctor'
+        ? withDoctorDiagnostics(data, discovery, doctorNextAction({ credential, anonymous: false }))
+        : data;
+      console.log(safeJson(output));
       process.exit(succeeded ? 0 : 1);
     }
 

--- a/test/xmemo-standalone-skill.test.js
+++ b/test/xmemo-standalone-skill.test.js
@@ -133,7 +133,7 @@ test('skill script doctor command calls /v1/skill/operations with operation doct
   testServer.setResponse({
     ok: true,
     operation: 'doctor',
-    result: { status: 'ok', auth_valid: true, scopes: ['memory:read'] }
+    result: { status: 'ok', auth_valid: true, scopes: ['memory:read'] },
   });
 
   const res = await runScript(['doctor'], {
@@ -151,6 +151,43 @@ test('skill script doctor command calls /v1/skill/operations with operation doct
   assert.equal(req.headers.authorization, 'Bearer secret-token-key');
 
   await testServer.stop();
+});
+
+test('skill script doctor --json reports bounded discovery diagnostics and a next action', async () => {
+  const testServer = createTestServer();
+  const baseUrl = await testServer.start();
+  testServer.setResponseSeq([
+    {
+      status: 200,
+      body: {
+        schema_version: '1.0',
+        protocol: 'memory-os-agent-discovery-v1',
+        service: 'memory-os',
+        standalone_skill: {
+          status: 'available',
+          runtime_model: 'standalone_skill',
+          operations: ['remember', 'recall', 'doctor'],
+          auth: { default_scopes: ['memory:read', 'memory:write'] },
+        },
+      },
+    },
+    { status: 200, body: { ok: true, operation: 'doctor', result: { auth_valid: false } } },
+  ]);
+
+  try {
+    const res = await runScript(['doctor', '--anonymous', '--json'], { baseUrl, env: {} });
+    assert.equal(res.code, 0);
+    const payload = JSON.parse(res.stdout);
+    assert.equal(payload.clientDiagnostics.discovery.status, 'available');
+    assert.equal(payload.clientDiagnostics.discovery.service, 'memory-os');
+    assert.deepEqual(payload.clientDiagnostics.discovery.standaloneSkill.operations, ['remember', 'recall', 'doctor']);
+    assert.equal(payload.clientDiagnostics.nextAction.command, 'node scripts/xmemo-skill.mjs auth status --verify');
+    assert.equal(testServer.requests.length, 2);
+    assert.equal(testServer.requests[0].headers.authorization, undefined);
+    assert.equal(testServer.requests[1].headers.authorization, undefined);
+  } finally {
+    await testServer.stop();
+  }
 });
 
 
@@ -174,6 +211,28 @@ test('skill script anonymous doctor command succeeds when no credentials are pre
   assert.match(res.stdout, /Authentication: Missing\/Unauthenticated/);
 
   await testServer.stop();
+});
+
+test('skill script doctor keeps a healthy JSON result when discovery is unavailable', async () => {
+  const testServer = createTestServer();
+  const baseUrl = await testServer.start();
+  testServer.setResponseSeq([
+    { status: 503, body: { error: 'discovery temporarily unavailable' } },
+    { status: 200, body: { ok: true, operation: 'doctor', result: { auth_valid: false } } },
+  ]);
+
+  try {
+    const res = await runScript(['doctor', '--json'], { baseUrl, env: {} });
+    assert.equal(res.code, 0);
+    const payload = JSON.parse(res.stdout);
+    assert.equal(payload.clientDiagnostics.discovery.status, 'unavailable');
+    assert.equal(payload.clientDiagnostics.discovery.errorCode, 'http_error');
+    assert.equal(payload.clientDiagnostics.discovery.httpStatus, 503);
+    assert.equal(payload.clientDiagnostics.nextAction.command, 'node scripts/xmemo-skill.mjs login --allow-plaintext');
+    assert.equal(testServer.requests.length, 2);
+  } finally {
+    await testServer.stop();
+  }
 });
 
 test('skill script doctor --anonymous does not transmit an available credential', async () => {


### PR DESCRIPTION
## XMemo Skill 1.1.4

Adds bounded, token-free `clientDiagnostics` to `doctor --json`:

- Read-only discovery service/capability summary.
- Concrete next credential-check or sign-in command.
- Stable degraded discovery status without failing an otherwise healthy doctor check.

Risk boundary: standalone Skill runtime, documentation, and regression tests only. No service/API, auth, scope, credential-storage, privacy, delete/retention, npm, tag, or release changes.

Validation:
- `verify-candidate.mjs`: pass; 4 allowlisted files, 182 added lines, `1.1.3 -> 1.1.4`.
- `npm run lint`: pass.
- `node --test test/xmemo-skill.test.js test/xmemo-standalone-skill.test.js`: 30 passed.
- `npm run pack:dry-run`: pass.

ClawHub baseline: `xmemo@1.1.3`, moderation `clean`. Public source baseline: `origin/main` at `e948653`.