### PR TITLE
fix(ci): use portable unzip quiet flag

### DIFF
--- a/.github/workflows/release-xmemo-skill.yml
+++ b/.github/workflows/release-xmemo-skill.yml
@@ -77,7 +77,7 @@ jobs:
           )
 
           tar --extract --gzip --file="$artifact_dir/xmemo-skill.tar.gz" --directory="$tar_extract_dir"
-          unzip --quiet "$artifact_dir/xmemo-skill.zip" -d "$zip_extract_dir"
+          unzip -q "$artifact_dir/xmemo-skill.zip" -d "$zip_extract_dir"
           diff --recursive --no-dereference "$tar_extract_dir" "$zip_extract_dir"
 
           for extracted_dir in "$tar_extract_dir" "$zip_extract_dir"; do


### PR DESCRIPTION
Fixes the Skill release asset workflow on GitHub Ubuntu by replacing the unsupported unzip --quiet option with unzip -q. The failure prevented v0.4.180 from uploading the verified tar/zip assets.