### PR TITLE
ci: separate Skill and npm release triggers

### DIFF
--- a/.github/workflows/release-xmemo-skill.yml
+++ b/.github/workflows/release-xmemo-skill.yml
@@ -2,6 +2,7 @@ name: Package XMemo Skill release assets
 
 on:
   release:
+    # Only skill-v<Skill semver> releases are packaged by the job gate below.
     types:
       - published
   workflow_dispatch:
@@ -16,10 +17,23 @@ permissions:
 
 jobs:
   package:
+    # Keep CLI v<CLI semver> npm releases and Skill releases independent.
+    if: >-
+      (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'skill-v')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(inputs.release_tag, 'skill-v'))
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
     steps:
+      - name: Validate Skill Release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^skill-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Skill releases must use a skill-v<major>.<minor>.<patch> tag; got: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
       - name: Check out the released tag
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,11 @@ name: Create Release
 
 on:
   push:
+    # CLI releases only: a v<CLI semver> tag publishes @xmemo/client to npm.
     tags:
       - 'v*.*.*'
 
 permissions:
-  actions: write
   contents: write
   id-token: write
 
@@ -49,13 +49,5 @@ jobs:
             --verify-tag \
             --title "${{ github.ref_name }}" \
             --generate-notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Dispatch Skill asset packaging
-        run: |
-          gh workflow run release-xmemo-skill.yml \
-            --ref "${{ github.event.repository.default_branch }}" \
-            -f release_tag="${{ github.ref_name }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Change\n- keep <CLI semver> tags dedicated to @xmemo/client npm publishing\n- require skill-v<Skill semver> for Skill archive packaging and xmemo.dev notification\n- remove the CLI workflow dispatch that linked the two flows\n\n## Validation\n- git diff --check\n- YAML parse plus trigger-separation assertions