### PR TITLE
feat(skill): add HTTPS installers

### DIFF
--- a/skills/xmemo/CHANGELOG.md
+++ b/skills/xmemo/CHANGELOG.md
@@ -1,5 +1,16 @@
 # XMemo Skill Change Log
 
+## 1.1.5
+
+- Add zero-dependency POSIX and PowerShell installers for the published
+  standalone Skill archive. Both enforce HTTPS-only download paths, reject
+  non-HTTPS redirects, verify the bundled runtime entrypoint, and never accept
+  or send XMemo credentials.
+- Document the installer commands and their destination/origin boundaries;
+  installation remains separate from explicit login and credential setup.
+- Regression coverage pins the HTTPS, redirect, entrypoint, and no-token
+  guarantees for both installer scripts.
+
 ## 1.1.4
 
 - `scripts/xmemo-skill.mjs`: add a bounded, token-free `clientDiagnostics`

--- a/skills/xmemo/SKILL.md
+++ b/skills/xmemo/SKILL.md
@@ -16,6 +16,25 @@ XMemo supports two parallel integration paths:
 
 Run bundled commands from the Skill root with Node.js 20 or newer.
 
+## Install The Standalone Skill
+
+For a fresh standalone installation, download the currently published Skill
+archive using the installer appropriate to the host:
+
+```text
+curl -fsSL https://xmemo.dev/v1/skill/package/install.sh | sh
+```
+
+```powershell
+irm https://xmemo.dev/v1/skill/package/install.ps1 | iex
+```
+
+Both installers require HTTPS, follow HTTPS-only redirects, and refuse to
+replace an existing destination. By default they create `xmemo-skill` in the
+current directory. Set `XMEMO_SKILL_DIR` to choose a new destination, or set
+`XMEMO_BASE_URL` only to a trusted HTTPS XMemo origin. They download and unpack
+the archive only; login and credential configuration remain explicit steps.
+
 ## Hosted Discovery Boundary
 
 The public `agent-discovery` field `standalone_skill.operations` describes the

--- a/skills/xmemo/install.ps1
+++ b/skills/xmemo/install.ps1
@@ -1,0 +1,46 @@
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Net.Http
+
+$baseUrl = if ($env:XMEMO_BASE_URL) { $env:XMEMO_BASE_URL.TrimEnd('/') } else { 'https://xmemo.dev' }
+$packageUrl = [Uri]"$baseUrl/v1/skill/package"
+$installDir = if ($env:XMEMO_SKILL_DIR) { $env:XMEMO_SKILL_DIR } else { 'xmemo-skill' }
+$tempDir = "$installDir.tmp.$PID"
+
+if ($packageUrl.Scheme -ne 'https') { throw 'XMemo Skill installer requires an HTTPS XMEMO_BASE_URL.' }
+if (Test-Path -LiteralPath $installDir) { throw "Destination already exists: $installDir" }
+$handler = [System.Net.Http.HttpClientHandler]::new()
+$handler.AllowAutoRedirect = $false
+$client = [System.Net.Http.HttpClient]::new($handler)
+try {
+  New-Item -ItemType Directory -Path $tempDir, "$tempDir\extract" | Out-Null
+  $archivePath = "$tempDir\xmemo-skill.tar.gz"
+  $uri = $packageUrl
+  $downloaded = $false
+  for ($redirects = 0; $redirects -lt 6; $redirects++) {
+    $response = $client.GetAsync($uri, [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead).GetAwaiter().GetResult()
+    if ([int]$response.StatusCode -ge 300 -and [int]$response.StatusCode -lt 400) {
+      if (-not $response.Headers.Location) { throw 'HTTPS redirect is missing a location.' }
+      $nextUri = [Uri]::new($uri, $response.Headers.Location)
+      $response.Dispose()
+      if ($nextUri.Scheme -ne 'https') { throw 'Refusing a non-HTTPS redirect.' }
+      $uri = $nextUri
+      continue
+    }
+    if (-not $response.IsSuccessStatusCode) { throw "Download failed: HTTP $([int]$response.StatusCode)" }
+    $stream = [System.IO.File]::Create($archivePath)
+    try { $response.Content.CopyToAsync($stream).GetAwaiter().GetResult() } finally { $stream.Dispose(); $response.Dispose() }
+    $downloaded = $true
+    break
+  }
+  if (-not $downloaded) { throw 'Too many redirects.' }
+  & tar.exe -xzf $archivePath -C "$tempDir\extract"
+  if ($LASTEXITCODE -ne 0) { throw 'Archive extraction failed.' }
+  if (-not (Test-Path -LiteralPath "$tempDir\extract\scripts\xmemo-skill.mjs" -PathType Leaf)) {
+    throw 'Archive does not contain xmemo-skill.'
+  }
+  Move-Item -LiteralPath "$tempDir\extract" -Destination $installDir
+  Write-Output "Installed XMemo Skill to $installDir"
+} finally {
+  $client.Dispose()
+  if (Test-Path -LiteralPath $tempDir) { Remove-Item -LiteralPath $tempDir -Recurse -Force }
+}

--- a/skills/xmemo/install.sh
+++ b/skills/xmemo/install.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Install the XMemo standalone Skill with only curl and tar available.
+set -eu
+
+base_url="${XMEMO_BASE_URL:-https://xmemo.dev}"
+case "$base_url" in https://*) ;; *) printf '%s\n' 'XMemo Skill installer requires an HTTPS XMEMO_BASE_URL.' >&2; exit 1 ;; esac
+package_url="${base_url%/}/v1/skill/package"
+install_dir="${XMEMO_SKILL_DIR:-xmemo-skill}"
+tmp_dir="${install_dir}.tmp.$$"
+
+fail() { printf '%s\n' "XMemo Skill installer: $1" >&2; exit 1; }
+[ ! -e "$install_dir" ] || fail "destination already exists: $install_dir"
+cleanup() { rm -rf "$tmp_dir"; }
+trap cleanup 0 HUP INT TERM
+
+mkdir "$tmp_dir" "$tmp_dir/extract" || fail "cannot create temporary directory"
+curl --fail --show-error --silent --location --proto '=https' --proto-redir '=https' \
+  "$package_url" -o "$tmp_dir/xmemo-skill.tar.gz" || fail "download failed"
+tar -xzf "$tmp_dir/xmemo-skill.tar.gz" -C "$tmp_dir/extract" || fail "archive extraction failed"
+[ -f "$tmp_dir/extract/scripts/xmemo-skill.mjs" ] || fail "archive does not contain xmemo-skill"
+mv "$tmp_dir/extract" "$install_dir" || fail "could not finalize installation"
+printf '%s\n' "Installed XMemo Skill to $install_dir"

--- a/skills/xmemo/scripts/xmemo-skill.mjs
+++ b/skills/xmemo/scripts/xmemo-skill.mjs
@@ -13,7 +13,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 
-const SKILL_VERSION = '1.1.4';
+const SKILL_VERSION = '1.1.5';
 const credentialsPath = path.join(os.homedir(), '.xmemo', 'skill-credentials.json');
 const registrationPath = path.join(os.homedir(), '.xmemo', 'skill-registration.json');
 const SCRIPT_COMMAND = 'node scripts/xmemo-skill.mjs';

--- a/test/xmemo-skill.test.js
+++ b/test/xmemo-skill.test.js
@@ -61,3 +61,22 @@ test('npm package includes the XMemo Skill, script, and references', async () =>
   assert.ok(packageJson.files.includes('skills'));
   assert.ok(packageJson.files.includes('plugins/xmemo'));
 });
+
+test('standalone Skill installers remain HTTPS-only and package the expected entrypoint', async () => {
+  const [posix, powershell] = await Promise.all([
+    readFile(path.join(repoRoot, 'skills/xmemo/install.sh'), 'utf8'),
+    readFile(path.join(repoRoot, 'skills/xmemo/install.ps1'), 'utf8'),
+  ]);
+
+  assert.match(posix, /XMEMO_BASE_URL:-https:\/\/xmemo\.dev/);
+  assert.match(posix, /--proto '=https'/);
+  assert.match(posix, /--proto-redir '=https'/);
+  assert.match(posix, /scripts\/xmemo-skill\.mjs/);
+  assert.doesNotMatch(posix, /XMEMO_KEY|Authorization/);
+
+  assert.match(powershell, /https:\/\/xmemo\.dev/);
+  assert.match(powershell, /AllowAutoRedirect = \$false/);
+  assert.match(powershell, /Refusing a non-HTTPS redirect/);
+  assert.match(powershell, /scripts\\xmemo-skill\.mjs/);
+  assert.doesNotMatch(powershell, /XMEMO_KEY|Authorization/);
+});


### PR DESCRIPTION
## XMemo Skill 1.1.5: HTTPS-only standalone installers

### Source and user value
- User-requested lightweight XMemo Skill release.
- Adds zero-dependency POSIX and PowerShell installers for the published Skill archive, reducing setup friction for standalone hosts.

### Release evidence
- Baseline: ClawHub `xmemo@1.1.4`, moderation `clean`; public `origin/main` skill runtime and changelog also `1.1.4`.
- Candidate: `1.1.5`, one commit, six allowlisted files, 118 added lines.
- Candidate verification: passed.
- `npm run lint`: passed.
- Focused tests: `node --test test/xmemo-skill.test.js test/xmemo-standalone-skill.test.js` — 31 passed.
- `npm run pack:dry-run`: passed; includes both installer files.

### Risk boundary
- Enforces HTTPS-only origins and redirects; verifies the unpacked runtime entrypoint.
- Does not accept or transmit XMemo credentials.
- Excludes npm/package metadata, service/API, authentication, scope, privacy, deletion, dependencies, and workflow changes.

After `CI / test` succeeds, release only through `promote-release.mjs` from a clean main checkout.