### PR TITLE
docs(skill): remove repeated install links

### DIFF
--- a/skills/xmemo/CHANGELOG.md
+++ b/skills/xmemo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # XMemo Skill Change Log
 
+## 1.1.6
+
+- Remove repeated standalone-installation links from `SKILL.md`; installation
+  distribution remains owned by the package and release surfaces, while this
+  Skill starts at runtime selection and explicit credential setup.
+
 ## 1.1.5
 
 - Add zero-dependency POSIX and PowerShell installers for the published

--- a/skills/xmemo/SKILL.md
+++ b/skills/xmemo/SKILL.md
@@ -16,25 +16,6 @@ XMemo supports two parallel integration paths:
 
 Run bundled commands from the Skill root with Node.js 20 or newer.
 
-## Install The Standalone Skill
-
-For a fresh standalone installation, download the currently published Skill
-archive using the installer appropriate to the host:
-
-```text
-curl -fsSL https://xmemo.dev/v1/skill/package/install.sh | sh
-```
-
-```powershell
-irm https://xmemo.dev/v1/skill/package/install.ps1 | iex
-```
-
-Both installers require HTTPS, follow HTTPS-only redirects, and refuse to
-replace an existing destination. By default they create `xmemo-skill` in the
-current directory. Set `XMEMO_SKILL_DIR` to choose a new destination, or set
-`XMEMO_BASE_URL` only to a trusted HTTPS XMemo origin. They download and unpack
-the archive only; login and credential configuration remain explicit steps.
-
 ## Hosted Discovery Boundary
 
 The public `agent-discovery` field `standalone_skill.operations` describes the

--- a/skills/xmemo/scripts/xmemo-skill.mjs
+++ b/skills/xmemo/scripts/xmemo-skill.mjs
@@ -13,7 +13,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 
-const SKILL_VERSION = '1.1.5';
+const SKILL_VERSION = '1.1.6';
 const credentialsPath = path.join(os.homedir(), '.xmemo', 'skill-credentials.json');
 const registrationPath = path.join(os.homedir(), '.xmemo', 'skill-registration.json');
 const SCRIPT_COMMAND = 'node scripts/xmemo-skill.mjs';


### PR DESCRIPTION
## Evidence

- Theme: remove repeated standalone-installation links from `skills/xmemo/SKILL.md`, per user documentation boundary.
- Version: standalone Skill `1.1.5` -> `1.1.6`; no `package.json` or npm metadata change.
- Baseline: `origin/main` `ab8b8bc714db3011b00cd8aa861b2268e693713b`; ClawHub `xmemo@1.1.5`, moderation `clean`, source manifest matched (only managed `skill-card.md` extra).
- Service observation: discovery/doctor healthy; service `0.4.345`, no capability delta selected.

## Validation

- `verify-candidate.mjs`: pass; 3 allowlisted files, +7 lines, one candidate commit.
- `npm run lint`: pass.
- `node --test test/xmemo-skill.test.js test/xmemo-standalone-skill.test.js`: 31/31 pass.
- `npm run pack:dry-run`: pass.

## Risk boundary

Documentation/runtime-version patch only. No service/API/auth/credential/scope/privacy/deletion/dependency/license/workflow or npm changes. `skill-card.md` untouched.