### PR TITLE
fix(ci): retry only the answers that can change on a second attempt

### DIFF
--- a/.github/workflows/release-xmemo-skill.yml
+++ b/.github/workflows/release-xmemo-skill.yml
@@ -205,24 +205,30 @@ jobs:
                 echo "Announcement accepted: HTTP $http_code"
                 break
                 ;;
-              4*)
-                echo "Announcement rejected with HTTP $http_code; not retrying." >&2
+              000 | 408 | 429 | 5*)
+                # A transport failure, a timeout, a rate limit, or a server
+                # error can each succeed later, so these share the retry
+                # handling below.
+                : ;;
+              *)
+                # Any other answer will not become a 2xx on retry, so it is
+                # reported at once instead of retried until the step times out.
+                echo "Announcement rejected with HTTP ${http_code:-none}; not retrying." >&2
                 head -c 500 "$response_body" >&2 || true
                 echo >&2
                 exit 1
                 ;;
-              *)
-                if [[ "$attempt" -ge "$max_attempts" ]]; then
-                  echo "Announcement failed after $attempt attempts (last status: ${http_code:-none})." >&2
-                  head -c 500 "$response_body" >&2 || true
-                  echo >&2
-                  exit 1
-                fi
-                echo "Announcement attempt $attempt failed (status: ${http_code:-none}); retrying." >&2
-                sleep "$((attempt * 3))"
-                attempt=$((attempt + 1))
-                ;;
             esac
+
+            if [[ "$attempt" -ge "$max_attempts" ]]; then
+              echo "Announcement failed after $attempt attempts (last status: ${http_code:-none})." >&2
+              head -c 500 "$response_body" >&2 || true
+              echo >&2
+              exit 1
+            fi
+            echo "Announcement attempt $attempt failed (status: ${http_code:-none}); retrying." >&2
+            sleep "$((attempt * 3))"
+            attempt=$((attempt + 1))
           done
 
       - name: Verify xmemo.dev serves this release

--- a/test/release-workflow.test.js
+++ b/test/release-workflow.test.js
@@ -25,7 +25,12 @@ test('the Skill release announcement fails fast instead of retrying a rejection'
   const workflow = await readFile(workflowPath, 'utf8');
 
   assert.doesNotMatch(workflow, /--retry-all-errors/);
-  assert.match(workflow, /Announcement rejected with HTTP \$http_code; not retrying\./);
+  assert.match(workflow, /Announcement rejected with HTTP \$\{http_code:-none\}; not retrying\./);
+
+  // Retrying every error turned one rejection into four identical rejections
+  // followed by an opaque failure. Only answers that can plausibly change on a
+  // second attempt are retried.
+  assert.match(workflow, /000 \| 408 \| 429 \| 5\*\)/);
 });
 
 test('the Skill release is verified against the public endpoint before it is called done', async () => {


### PR DESCRIPTION
## Problem

The previous change classified every `4xx` as final. A `429` rate limit or a
`408` timeout would then fail the release on the first answer, even though both
can succeed moments later.

An intermediate version tried to handle this with an empty `408 | 429)` branch,
which does not work: `;;` ends the branch instead of falling through, so a
retryable status would have left the `while` loop spinning with no delay and no
attempt counter.

## Changes

- Retry `000` (transport failure), `408`, `429`, and `5xx`; report anything else at once.
- Move the retry bookkeeping out of a case branch to after the `case` statement, so no status can skip the delay or the attempt count.

## Verification

The retry loop was extracted from the parsed workflow with the HTTP call
replaced by a stub that returns a scripted sequence of status codes:

| Scenario | Exit | Retried | Outcome |
| --- | --- | --- | --- |
| 202 | 0 | 0 | accepted |
| 403 | 1 | 0 | not retried |
| 401 | 1 | 0 | not retried |
| 404 | 1 | 0 | not retried |
| 429 then 202 | 0 | 1 | accepted |
| 500 then 202 | 0 | 1 | accepted |
| 000 then 202 | 0 | 1 | accepted |
| 408 throughout | 1 | 2 | failed after 3 attempts |
| 503 throughout | 1 | 2 | failed after 3 attempts |

`npm run lint` clean, `npm test` 140/140.