### PR TITLE
docs(skill): consolidate command examples

### DIFF
--- a/skills/xmemo/CHANGELOG.md
+++ b/skills/xmemo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # XMemo Skill Change Log
 
+## 1.1.8
+
+- Consolidate repeated command examples in `SKILL.md`: document each canonical
+  command once, while retaining `auth-status` as a runtime compatibility alias.
+
 ## 1.1.7
 
 - Stop shipping `install.sh` and `install.ps1` inside the published Skill. Their

--- a/skills/xmemo/SKILL.md
+++ b/skills/xmemo/SKILL.md
@@ -144,7 +144,6 @@ The Skill script handles all operations directly, including status checks and to
 
 ```text
 node scripts/xmemo-skill.mjs auth status [--verify]
-node scripts/xmemo-skill.mjs auth-status [--verify]
 node scripts/xmemo-skill.mjs auth add --from-stdin --allow-plaintext
 node scripts/xmemo-skill.mjs auth claim-status [--allow-plaintext]
 node scripts/xmemo-skill.mjs auth claim-confirm [--allow-plaintext]
@@ -160,15 +159,10 @@ variable in the launching environment to stop using it.
 
 ## Setup And Repair
 
-If the bundled script reports auth or service errors, use the Skill diagnostics command:
-
-```text
-node scripts/xmemo-skill.mjs doctor
-node scripts/xmemo-skill.mjs doctor --anonymous
-node scripts/xmemo-skill.mjs auth status --verify
-node scripts/xmemo-skill.mjs auth-status --verify
-node scripts/xmemo-skill.mjs auth claim-status
-```
+If the bundled script reports auth or service errors, use the canonical commands
+above: `doctor`, `doctor --anonymous`, `auth status --verify`, and
+`auth claim-status`. The `auth-status` spelling remains a compatibility alias,
+but it is intentionally not repeated in this reference.
 
 `doctor` retains authenticated diagnosis when a credential is available.
 `doctor --anonymous` performs the same service-health check without sending an

--- a/skills/xmemo/scripts/xmemo-skill.mjs
+++ b/skills/xmemo/scripts/xmemo-skill.mjs
@@ -13,7 +13,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 
-const SKILL_VERSION = '1.1.7';
+const SKILL_VERSION = '1.1.8';
 const credentialsPath = path.join(os.homedir(), '.xmemo', 'skill-credentials.json');
 const registrationPath = path.join(os.homedir(), '.xmemo', 'skill-registration.json');
 const SCRIPT_COMMAND = 'node scripts/xmemo-skill.mjs';


### PR DESCRIPTION
## Evidence

- Theme: consolidate repeated command examples in `skills/xmemo/SKILL.md`.
- The runtime preserves `auth-status` as a compatibility alias; documentation presents only the canonical `auth status` spelling and no longer duplicates setup commands.
- Baseline: `origin/main` `ed4707c1c526381d6d49726e1be0bd2d1f4ccbcb`; ClawHub `xmemo@1.1.7`, moderation `clean`, source manifest matched (only managed `skill-card.md` extra).

## Validation

- `verify-candidate.mjs`: pass; 3 allowlisted files, +10 lines, one candidate commit.
- `npm run lint`: pass.
- `node --test test/xmemo-skill.test.js test/xmemo-standalone-skill.test.js`: 31/31 pass.
- `npm run pack:dry-run`: pass.

## Risk boundary

Documentation/runtime-version patch only. No service/API/auth/credential/scope/privacy/deletion/dependency/license/workflow or npm changes. `skill-card.md` untouched.