### PR TITLE
fix: fit MCP Registry description limit

### DIFF
--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "yonro-memory-os-cli",
   "name": "XMemo CLI",
-  "description": "Shared, governed long-term memory for AI agents — durable context across tools and sessions, exposed via MCP and REST.",
+  "description": "Shared, governed long-term memory for AI agents across tools and sessions via MCP and REST.",
   "author": "yonro",
   "authorUrl": "https://github.com/yonro",
   "homepage": "https://xmemo.dev/product/mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.yonro/xmemo",
   "title": "XMemo",
-  "description": "Shared, governed long-term memory for AI agents — durable context across tools and sessions, exposed via MCP and REST.",
+  "description": "Shared, governed long-term memory for AI agents across tools and sessions via MCP and REST.",
   "websiteUrl": "https://xmemo.dev/product/mcp",
   "repository": {
     "url": "https://github.com/yonro/memory-os-cli",


### PR DESCRIPTION
Fixes the Registry submission rejection: its description field is limited to 100 characters.\n\nKeeps the production XMemo positioning intact in a schema-compliant 91-character form for both the MCP Registry manifest and LobeHub manifest.\n\nValidation: npm run prepublishOnly (140 tests, lint, package dry-run).