### PR TITLE
feat(skill): expose discovery compatibility details

### DIFF
--- a/skills/xmemo/CHANGELOG.md
+++ b/skills/xmemo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # XMemo Skill Change Log
 
+## 1.1.9
+
+- Expand the bounded, read-only `doctor --json` discovery summary with the
+  advertised service version, MCP URL, and supported clients so agents can
+  diagnose compatibility without parsing the raw discovery document.
+- Preserve existing anonymous, credential, health-check, and degraded-discovery
+  behavior; the new fields come only from the public discovery response.
+
 ## 1.1.8
 
 - Consolidate repeated command examples in `SKILL.md`: document each canonical

--- a/skills/xmemo/SKILL.md
+++ b/skills/xmemo/SKILL.md
@@ -128,9 +128,12 @@ The script supports JSON output with `--json`, command-specific usage with
 `--help`, `--version`, per-request timeouts with `--timeout-ms`, and compact
 recall/search output with `--compact`. `doctor --json` adds a bounded
 `clientDiagnostics` object: a read-only discovery summary and a `nextAction`
-command for the next credential check or formal sign-in. If discovery is
-unavailable, `clientDiagnostics.discovery.status` is `unavailable`; a successful
-doctor health check still succeeds. It never prints token values or prefixes.
+command for the next credential check or formal sign-in. The summary includes
+the advertised service version, MCP URL, supported clients, and standalone Skill
+operations so compatibility can be checked without inspecting the raw discovery
+document. If discovery is unavailable, `clientDiagnostics.discovery.status` is
+`unavailable`; a successful doctor health check still succeeds. It never prints
+token values or prefixes.
 
 When native XMemo MCP tools are present, use `create_restart_snapshot` and
 `restore_restart_snapshot` for the same full-continuity workflow. The bundled

--- a/skills/xmemo/scripts/xmemo-skill.mjs
+++ b/skills/xmemo/scripts/xmemo-skill.mjs
@@ -13,7 +13,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 
-const SKILL_VERSION = '1.1.8';
+const SKILL_VERSION = '1.1.9';
 const credentialsPath = path.join(os.homedir(), '.xmemo', 'skill-credentials.json');
 const registrationPath = path.join(os.homedir(), '.xmemo', 'skill-registration.json');
 const SCRIPT_COMMAND = 'node scripts/xmemo-skill.mjs';
@@ -431,6 +431,9 @@ function summarizeDoctorDiscovery(discovery, discoveryUrl) {
     schemaVersion: discoveryString(discovery?.schema_version),
     protocol: discoveryString(discovery?.protocol),
     service: discoveryString(discovery?.service),
+    serviceVersion: discoveryString(discovery?.service_version),
+    mcpUrl: discoveryString(discovery?.mcp_url),
+    supportedClients: discoveryStringList(discovery?.supported_clients),
     standaloneSkill: {
       status: discoveryString(standalone.status),
       runtimeModel: discoveryString(standalone.runtime_model),

--- a/test/xmemo-standalone-skill.test.js
+++ b/test/xmemo-standalone-skill.test.js
@@ -163,6 +163,9 @@ test('skill script doctor --json reports bounded discovery diagnostics and a nex
         schema_version: '1.0',
         protocol: 'memory-os-agent-discovery-v1',
         service: 'memory-os',
+        service_version: '0.4.346',
+        mcp_url: 'https://xmemo.dev/mcp',
+        supported_clients: ['codex', 'claude-code', 'openclaw'],
         standalone_skill: {
           status: 'available',
           runtime_model: 'standalone_skill',
@@ -180,6 +183,9 @@ test('skill script doctor --json reports bounded discovery diagnostics and a nex
     const payload = JSON.parse(res.stdout);
     assert.equal(payload.clientDiagnostics.discovery.status, 'available');
     assert.equal(payload.clientDiagnostics.discovery.service, 'memory-os');
+    assert.equal(payload.clientDiagnostics.discovery.serviceVersion, '0.4.346');
+    assert.equal(payload.clientDiagnostics.discovery.mcpUrl, 'https://xmemo.dev/mcp');
+    assert.deepEqual(payload.clientDiagnostics.discovery.supportedClients, ['codex', 'claude-code', 'openclaw']);
     assert.deepEqual(payload.clientDiagnostics.discovery.standaloneSkill.operations, ['remember', 'recall', 'doctor']);
     assert.equal(payload.clientDiagnostics.nextAction.command, 'node scripts/xmemo-skill.mjs auth status --verify');
     assert.equal(testServer.requests.length, 2);


### PR DESCRIPTION
## Summary

- expose public discovery `serviceVersion`, `mcpUrl`, and bounded `supportedClients` in standalone `doctor --json`
- document the compatibility diagnostics and bump only the standalone Skill patch to `1.1.9`
- preserve anonymous, credential, health-check, degraded-discovery, API, and scope behavior

## Source evidence and user value

MemoryOS discovery `0.4.346` advertises these compatibility fields, and the top-level CLI doctor reports them. The standalone Skill already reads the same public document but omitted them, forcing agents to parse raw discovery output.

## Validation

- `verify-candidate.mjs`: passed; 4 allowlisted files, 24 added lines, `1.1.8 -> 1.1.9`
- `npm run lint`: passed
- focused tests: 31/31 passed
- `npm run pack:dry-run`: passed

## Risk boundary

No npm version or publication, service/API/auth/credential/scope/deletion/privacy/retention/dependency/license change, `skill-card.md`, workflow, release script, allowlist, or direct `main` push. ClawHub baseline is `xmemo@1.1.8`, moderation clean, with matching source hashes.
