### PR TITLE
fix(skill): clarify plain doctor diagnostics

### DIFF
--- a/skills/xmemo/CHANGELOG.md
+++ b/skills/xmemo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # XMemo Skill Change Log
 
+## 1.1.10
+
+- Clarify plain-text `doctor` output: an explicit `--anonymous` health check
+  now says authentication was not checked, while a normal no-credential check
+  prints the formal-login next command.
+- Preserve the existing read-only health request, JSON diagnostics, credential
+  lookup, authentication, scope, and degraded-discovery behavior.
+
 ## 1.1.9
 
 - Expand the bounded, read-only `doctor --json` discovery summary with the

--- a/skills/xmemo/SKILL.md
+++ b/skills/xmemo/SKILL.md
@@ -171,7 +171,9 @@ but it is intentionally not repeated in this reference.
 `doctor --anonymous` performs the same service-health check without sending an
 Authorization header. Both forms use only an unauthenticated, read-only
 discovery request for their JSON capability summary; discovery failure does not
-block an otherwise successful health check.
+block an otherwise successful health check. In terminal output, an explicit
+anonymous check says authentication was not checked; a normal no-credential
+check instead prints the formal-login next command.
 
 For detailed examples, read `references/operations.md`. For auth, network, and service diagnosis, read `references/troubleshooting.md`.
 

--- a/skills/xmemo/scripts/xmemo-skill.mjs
+++ b/skills/xmemo/scripts/xmemo-skill.mjs
@@ -13,7 +13,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 
-const SKILL_VERSION = '1.1.9';
+const SKILL_VERSION = '1.1.10';
 const credentialsPath = path.join(os.homedir(), '.xmemo', 'skill-credentials.json');
 const registrationPath = path.join(os.homedir(), '.xmemo', 'skill-registration.json');
 const SCRIPT_COMMAND = 'node scripts/xmemo-skill.mjs';
@@ -1207,7 +1207,13 @@ async function main() {
           anonymous: options.anonymous,
         }))));
       } else {
-        console.log(`XMemo Service Status: OK\nAuthentication: Missing/Unauthenticated`);
+        const authentication = options.anonymous
+          ? 'Not checked (anonymous mode)'
+          : 'Missing/Unauthenticated';
+        const nextStep = options.anonymous
+          ? ''
+          : `\nNext: ${SCRIPT_COMMAND} login --allow-plaintext`;
+        console.log(`XMemo Service Status: OK\nAuthentication: ${authentication}${nextStep}`);
       }
       process.exit(0);
     } catch (e) {

--- a/test/xmemo-standalone-skill.test.js
+++ b/test/xmemo-standalone-skill.test.js
@@ -215,6 +215,7 @@ test('skill script anonymous doctor command succeeds when no credentials are pre
   assert.equal(res.code, 0);
   assert.match(res.stdout, /XMemo Service Status: OK/);
   assert.match(res.stdout, /Authentication: Missing\/Unauthenticated/);
+  assert.match(res.stdout, /Next: node scripts\/xmemo-skill\.mjs login --allow-plaintext/);
 
   await testServer.stop();
 });
@@ -256,7 +257,8 @@ test('skill script doctor --anonymous does not transmit an available credential'
   });
 
   assert.equal(res.code, 0);
-  assert.match(res.stdout, /Authentication: Missing\/Unauthenticated/);
+  assert.match(res.stdout, /Authentication: Not checked \(anonymous mode\)/);
+  assert.doesNotMatch(res.stdout, /Next:/);
   assert.equal(testServer.requests.length, 1);
   assert.equal(testServer.requests[0].headers.authorization, undefined);
 


### PR DESCRIPTION
## Summary

Clarifies the standalone XMemo Skill's plain-text `doctor` diagnostics.

- An explicit `doctor --anonymous` check now states that authentication was not checked.
- A normal no-credential health check now gives the formal-login command.
- The change preserves the existing read-only health request, JSON diagnostics, credential lookup, authentication, scope, and degraded-discovery behavior.

## Evidence and scope

The live baseline is ClawHub `xmemo@1.1.9`, clean, matching `origin/main`.
This one-theme candidate changes only four permitted XMemo Skill/test files and advances the standalone Skill to `1.1.10`.

## Validation

- `verify-candidate.mjs`: passed (`1.1.9` -> `1.1.10`; 4 files; 22 added lines)
- `npm run lint`: passed
- `node --test test/xmemo-skill.test.js test/xmemo-standalone-skill.test.js`: passed (31/31)
- `npm run pack:dry-run`: passed

No service, API, authentication, scope, credential, privacy, retention, dependency, licence, package, or npm-release changes are included.
