### PR TITLE
docs(skill): clarify standalone discovery description

### DIFF
--- a/skills/xmemo/CHANGELOG.md
+++ b/skills/xmemo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # XMemo Skill Change Log
 
+## 1.1.11
+
+- Simplify the standalone Skill description so agents can discover its core
+  memory, continuity, TODO, expense, and diagnostics workflows without an
+  exhaustive command list.
+- Preserve the existing runtime commands, authentication, scopes, service
+  requests, and MCP fallback behavior.
+
 ## 1.1.10
 
 - Clarify plain-text `doctor` output: an explicit `--anonymous` health check

--- a/skills/xmemo/SKILL.md
+++ b/skills/xmemo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xmemo-memory
-description: Persistent user-owned memory for agents with standalone runtime execution. Use when an agent should remember, recall, search memory, preserve restart continuity, manage TODOs, record expenses, diagnose XMemo auth, or operate XMemo even when MCP tools are not configured.
+description: Persistent, user-owned memory for agents. Use the standalone runtime to remember, recall, search, preserve restart continuity, manage TODOs and expenses, or diagnose XMemo when MCP tools are unavailable.
 ---
 
 # XMemo Memory

--- a/skills/xmemo/scripts/xmemo-skill.mjs
+++ b/skills/xmemo/scripts/xmemo-skill.mjs
@@ -13,7 +13,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 
-const SKILL_VERSION = '1.1.10';
+const SKILL_VERSION = '1.1.11';
 const credentialsPath = path.join(os.homedir(), '.xmemo', 'skill-credentials.json');
 const registrationPath = path.join(os.homedir(), '.xmemo', 'skill-registration.json');
 const SCRIPT_COMMAND = 'node scripts/xmemo-skill.mjs';


### PR DESCRIPTION
## Summary

- simplify the standalone Skill frontmatter description around its core memory, continuity, TODO, expense, and diagnostics workflows
- bump only the standalone Skill patch from 1.1.10 to 1.1.11 and add the matching changelog entry

## Evidence and validation

- ClawHub baseline: xmemo 1.1.10, moderation clean, source manifest verified by promote-release.mjs
- public origin/main baseline: 784144445da87bc4d017fd11765d1336f076faba
- candidate gate: passed (3 allowlisted files, +10 lines, next patch 1.1.11)
- npm run lint: passed
- focused tests: node --test test/xmemo-skill.test.js test/xmemo-standalone-skill.test.js (31/31 passed)
- npm run pack:dry-run: passed

## Risk boundary

Docs/discoverability wording only. No changes to runtime behavior, network requests, authentication, credentials, scopes, service/API, deletion, privacy, dependencies, npm metadata, or release automation. skill-card.md is unchanged.