### PR TITLE
docs(skill): add first successful run path

### DIFF
--- a/skills/xmemo/CHANGELOG.md
+++ b/skills/xmemo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # XMemo Skill Change Log
 
+## 1.1.12
+
+- Add a short first-successful-run path: anonymous service health check,
+  deliberate credential choice, and credential verification before memory work.
+- Preserve runtime commands, network requests, authentication, scopes,
+  credential behavior, service APIs, and MCP fallback behavior.
+
 ## 1.1.11
 
 - Simplify the standalone Skill description so agents can discover its core

--- a/skills/xmemo/SKILL.md
+++ b/skills/xmemo/SKILL.md
@@ -7,6 +7,35 @@ description: Persistent, user-owned memory for agents. Use the standalone runtim
 
 Give your agent durable memory that survives across sessions, projects, and tools.
 
+## First Successful Run
+
+After ClawHub installs this Skill, run these commands from the Skill root to
+confirm the service and choose an authentication path in a few minutes:
+
+1. Check public service reachability without sending a credential:
+
+   ```text
+   node scripts/xmemo-skill.mjs doctor --anonymous
+   ```
+
+2. For account-backed memory, prefer an `XMEMO_KEY` supplied by a managed
+   secret store. Otherwise, start the formal device-login flow only when you
+   explicitly accept local plaintext credential storage:
+
+   ```text
+   node scripts/xmemo-skill.mjs login --allow-plaintext
+   ```
+
+3. Confirm the credential before running memory operations:
+
+   ```text
+   node scripts/xmemo-skill.mjs auth status --verify
+   ```
+
+If a command fails, use the exact next action it prints, then read
+`references/troubleshooting.md`. Once the check succeeds, continue with
+**Core Workflows** below.
+
 ## Runtime Selection
 
 XMemo supports two parallel integration paths:

--- a/skills/xmemo/scripts/xmemo-skill.mjs
+++ b/skills/xmemo/scripts/xmemo-skill.mjs
@@ -13,7 +13,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 
-const SKILL_VERSION = '1.1.11';
+const SKILL_VERSION = '1.1.12';
 const credentialsPath = path.join(os.homedir(), '.xmemo', 'skill-credentials.json');
 const registrationPath = path.join(os.homedir(), '.xmemo', 'skill-registration.json');
 const SCRIPT_COMMAND = 'node scripts/xmemo-skill.mjs';

--- a/test/xmemo-skill.test.js
+++ b/test/xmemo-skill.test.js
@@ -13,6 +13,11 @@ test('XMemo Skill describes standalone CLI-backed runtime selection', async () =
 
   assert.match(skill, /^---\nname: xmemo-memory\ndescription: .+\n---\n/);
   assert.match(skill, /Runtime Selection/);
+  assert.match(skill, /First Successful Run/);
+  assert.match(skill, /After ClawHub installs this Skill/);
+  assert.match(skill, /doctor --anonymous/);
+  assert.match(skill, /auth status --verify/);
+  assert.match(skill, /managed\n+   secret store/);
   assert.match(skill, /scripts\/xmemo-skill\.mjs/);
   assert.doesNotMatch(skill, /node skills\/xmemo\/scripts\/xmemo-skill\.mjs/);
   assert.match(skill, /xmemo-skill\.mjs login/);


### PR DESCRIPTION
## Summary

Adds one short, ordered onboarding path directly after the XMemo Skill introduction:

1. Anonymous service health check.
2. Deliberate credential choice, preferring managed `XMEMO_KEY` storage.
3. Credential verification before memory operations.

## Evidence and boundary

- User-selected low-risk docs-only onboarding improvement.
- ClawHub baseline: `xmemo@1.1.11`, moderation `clean`, public main `9340964ebf99cf2289f47621444cf200cf0ad933`.
- Exactly 4 allowlisted files; `+42/-1`; standalone Skill `1.1.11 -> 1.1.12`.
- No API, service, authentication, scope, credential behavior, dependency, npm, or `skill-card.md` change.

## Validation

- `verify-candidate.mjs`: passed.
- `npm run lint`: passed.
- `node --test test/xmemo-skill.test.js test/xmemo-standalone-skill.test.js`: 31/31 passed.
- `npm run pack:dry-run`: passed.