### PR TITLE
docs: add context7.json and repair unreachable documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,9 +508,22 @@ GitHub Release cannot publish twice.
 
 ## Documentation and support
 
+Canonical service documentation lives at [xmemo.dev/docs](https://xmemo.dev/docs/quickstart).
+This repository documents the client; the pages below document the hosted service
+it connects to.
+
+| | |
+| --- | --- |
+| **Quickstart** | [xmemo.dev/docs/quickstart](https://xmemo.dev/docs/quickstart) |
+| **MCP overview and per-client setup** | [xmemo.dev/docs/mcp/overview](https://xmemo.dev/docs/mcp/overview) |
+| **Tool reference** (`remember`, `recall`, `search`, …) | [xmemo.dev/docs/tools/remember](https://xmemo.dev/docs/tools/remember) |
+| **REST API** | [xmemo.dev/docs/api/authentication](https://xmemo.dev/docs/api/authentication) |
+| **Troubleshooting** | [xmemo.dev/docs/troubleshooting](https://xmemo.dev/docs/troubleshooting) |
+| **Machine-readable index** | [xmemo.dev/llms.txt](https://xmemo.dev/llms.txt) |
+
 - [XMemo](https://xmemo.dev)
-- [XMemo MCP guide](https://xmemo.dev/product/mcp)
 - [MCP server reference](./MCP-README.md)
+- [Adding a new client](./ADDING_CLIENTS.md)
 - [Issues](https://github.com/yonro/memory-os-cli/issues)
 - [Releases](https://github.com/yonro/memory-os-cli/releases)
 

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "XMemo CLI",
+  "description": "Official CLI and MCP setup helper for XMemo (@xmemo/client). Connects editors, CLIs, and autonomous agents to a private memory layer while keeping credentials out of project files.",
+  "branch": "main",
+  "folders": [],
+  "excludeFolders": [
+    "test",
+    "tests",
+    ".github",
+    "scripts",
+    "dist",
+    "node_modules",
+    ".worktrees",
+    ".progress",
+    ".tmp-mcp-test",
+    "docs/assets"
+  ],
+  "excludeFiles": [
+    "package-lock.json",
+    "glama.json"
+  ],
+  "rules": [
+    "Use https://xmemo.dev/mcp as the canonical hosted XMemo MCP endpoint.",
+    "Install the CLI as the npm package @xmemo/client; the primary command is `xmemo`.",
+    "Use the authentication mode documented for the specific MCP client; prefer OAuth only where that client profile explicitly supports it.",
+    "Never hardcode XMEMO_KEY, bearer tokens, API keys, passwords, or other credentials in public configuration, source code, or generated client config files.",
+    "For token-based clients, read XMEMO_KEY from an environment variable or supported secret store.",
+    "Treat X-Memory-OS-Agent-ID and XMEMO_AGENT_INSTANCE_ID as attribution identifiers, not authentication credentials.",
+    "Keep XMEMO_AGENT_INSTANCE_ID stable for the same local installation or autonomous runner; generate a different value for a different local agent profile.",
+    "Prefer `xmemo mcp add <client> --write` over hand-editing a client config file, so the stable instance identity is generated correctly.",
+    "`xmemo setup` is dry-run by default; configuration is only written when --write or --yes is passed.",
+    "Use `xmemo doctor` and `xmemo status` to diagnose a connection before changing configuration.",
+    "`xmemo uninstall` removes only XMemo-owned entries and marker-scoped behavior profiles; unrelated MCP servers, credentials, and device identity are left intact.",
+    "Use only XMemo commands, flags, tools, SDK helpers, parameters, scopes, and endpoints that are explicitly documented. Never invent XMemo APIs, tool names, or CLI flags.",
+    "Store durable and reusable context in XMemo, such as project facts, decisions, preferences, corrections, and handoff information; avoid transient conversation noise.",
+    "Preserve documented project, memory scope, provenance, and attribution semantics when saving or retrieving context.",
+    "Prefer the current canonical XMemo developer documentation at https://xmemo.dev/docs/quickstart over old examples, marketing pages, third-party snippets, or deprecated configuration.",
+    "This repository is the public client. The XMemo service repository is private; do not link readers to github.com/yunze7373/memory-os, which is not publicly reachable."
+  ]
+}

--- a/plugins/kiro/POWER.md
+++ b/plugins/kiro/POWER.md
@@ -142,7 +142,7 @@ To remove XMemo from Kiro, manually edit `~/.kiro/settings/mcp.json` and remove 
 - All memory content is user-owned and controlled through your XMemo account
 ## License and support
 
-This power is licensed under [LicenseRef-Proprietary](file:///h:/repos/memory-os-cli/plugins/kiro/LICENSE).
+This power is licensed under [LicenseRef-Proprietary](./LICENSE).
 This power integrates with XMemo MCP Server (LicenseRef-Proprietary).
-- [Privacy Policy](https://xmemo.dev/privacy)
+- [Privacy Policy](https://xmemo.dev/legal/privacy)
 - [Support](mailto:support@xmemo.dev)


### PR DESCRIPTION
## Why

Context7 currently indexes XMemo only as a **website crawl** of `xmemo.dev`
(`/websites/xmemo_dev_product`, 34 code snippets, Source Reputation `Low`, no
Benchmark Score). The service repository is private, so a repo-backed library was
assumed to be impossible.

This repository is public, active, and is the actual source of `@xmemo/client` on
npm — 143 tracked files, 101 KB of markdown across 21 documents, plus the CLI
implementation in `src/`. Context7 does not index it and it carries no
`context7.json`.

Comparable libraries in this category sit at 1,442–5,428 snippets. A repo-backed
library is also the only path that earns Source Reputation from real repository
activity, which a website crawl cannot provide.

## Changes

**`context7.json`** (new) — validated against
`https://context7.com/schema/context7.json` with a real JSON Schema run, not by
eye. `description` is 180 characters against the schema's 200 limit; the first
draft was 207 and would have been rejected.

`folders` is deliberately left empty so the whole repository is scanned: the
usable content is spread across the root markdown, `skills/`, `plugins/`,
`extensions/` and `src/`, whereas `docs/` holds only two SVG assets. Simulating
the config against `git ls-files` gives **117 of 143 tracked files indexed**, with
26 excluded — CI workflows, lockfiles, changelogs, tests, build scripts and SVGs.

The 16 `rules` were checked against the implementation rather than written from
memory. For example `setup <client-id> [--url <url>]` and
`mcp add <client-id> [--write]` are both declared in `src/ui/help.js`.

**Two links that do not resolve:**

- `plugins/kiro/POWER.md` pointed at `https://xmemo.dev/privacy` → **HTTP 404**.
  The published page is `/legal/privacy`.
- The same file linked its licence through
  `file:///h:/repos/memory-os-cli/plugins/kiro/LICENSE` — an absolute path from
  another machine that had leaked into published documentation. Now `./LICENSE`.

Both live in files an indexer will read.

**`README.md`** — the documentation section did not link to the canonical service
documentation tree at `xmemo.dev/docs` anywhere in the repository. Added, with
quickstart, MCP, tools, API, troubleshooting and `llms.txt` entries.

## Verification

- `context7.json` validates against the official schema (jsonschema, Draft 2020-12)
- All 7 added URLs return **200**; all 3 relative paths exist
- `node --test "test/**/*.test.js"` → **140 passed, 0 failed** (before and after)
- `context7.json` is not published to npm — `package.json` uses a `files` allowlist

## Follow-up (human step)

Adding `context7.json` does not itself trigger indexing. The repository still has
to be submitted at <https://context7.com/add-library> as
`https://github.com/yonro/memory-os-cli`.

After that XMemo has two Context7 libraries: `/websites/xmemo_dev_product` for the
hosted service and `/yonro/memory-os-cli` for the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
