### PR TITLE
docs(skill): align runtime with Node 22.22

### DIFF
--- a/skills/xmemo/CHANGELOG.md
+++ b/skills/xmemo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # XMemo Skill Change Log
 
+## 1.1.14
+
+- Align the documented standalone Skill runtime with the MemoryOS Node.js
+  baseline: Node.js 22.22.0 or newer.
+- Keep the runtime behavior, authentication, scopes, service APIs, and package
+  metadata unchanged.
+
 ## 1.1.13
 
 - Add the read-only `recall-context` command for the service's bounded,

--- a/skills/xmemo/SKILL.md
+++ b/skills/xmemo/SKILL.md
@@ -43,7 +43,8 @@ XMemo supports two parallel integration paths:
 1. **Bundled Skill script** at `scripts/xmemo-skill.mjs` (primary standalone direct REST API integration, fully self-contained and zero-dependency).
 2. **XMemo MCP tools** (when running in environments that natively host the XMemo MCP server).
 
-Run bundled commands from the Skill root with Node.js 20 or newer.
+Run bundled commands from the Skill root with Node.js 22.22.0 or newer. This
+matches the MemoryOS service and repository runtime baseline.
 
 ## Hosted Discovery Boundary
 

--- a/skills/xmemo/references/operations.md
+++ b/skills/xmemo/references/operations.md
@@ -17,7 +17,7 @@ bundled `xmemo` Skill. This is the primary standalone runtime for direct REST ac
 
 XMemo supports two parallel integration paths:
 
-1. **Bundled Skill script** (`node scripts/xmemo-skill.mjs <command>`), which directly integrates with the XMemo REST API using stored credentials. Run commands from the Skill root with Node.js 20 or newer.
+1. **Bundled Skill script** (`node scripts/xmemo-skill.mjs <command>`), which directly integrates with the XMemo REST API using stored credentials. Run commands from the Skill root with Node.js 22.22.0 or newer, matching the MemoryOS service and repository runtime baseline.
 2. **XMemo MCP tools** (when running in environments that natively host the XMemo MCP server).
 
 Credential resolution is `XMEMO_KEY` first, then the user-scoped credential

--- a/skills/xmemo/scripts/xmemo-skill.mjs
+++ b/skills/xmemo/scripts/xmemo-skill.mjs
@@ -13,7 +13,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 
-const SKILL_VERSION = '1.1.13';
+const SKILL_VERSION = '1.1.14';
 const credentialsPath = path.join(os.homedir(), '.xmemo', 'skill-credentials.json');
 const registrationPath = path.join(os.homedir(), '.xmemo', 'skill-registration.json');
 const SCRIPT_COMMAND = 'node scripts/xmemo-skill.mjs';


### PR DESCRIPTION
## Summary\n- align standalone XMemo Skill runtime guidance with MemoryOS Node.js 22.22.0 baseline\n- bump standalone Skill patch version to 1.1.14\n- preserve runtime behavior, authentication, scopes, service APIs, and npm metadata\n\n## Evidence and validation\n- live MemoryOS service discovery: 0.4.360; repository package.json and deploy workflows require Node.js >=22.22.0 / 22.22.0\n- ClawHub baseline: xmemo 1.1.13, moderation clean\n- base origin/main: 2f3ae89617fcd25a15a84ee302cc06cf03e1dbe5\n- candidate commit: 626c736\n- changed files: 4; additions: 11; only skills/xmemo/**\n- verify-candidate: passed (candidate-only, 1.1.14)\n- npm run lint: passed\n- focused tests: 32/32 passed\n- npm run pack:dry-run: passed\n- git diff --check: passed\n\nNo package.json/npm, service, auth, scope, dependency, license, or release-tool changes.