### PR TITLE
fix(skill): retain discovery package version

### DIFF
--- a/skills/xmemo/CHANGELOG.md
+++ b/skills/xmemo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # XMemo Skill Change Log
 
+## 1.1.16
+
+- Preserve the read-only `doctor --json` discovery summary when a service omits
+  top-level `service_version`: expose the separately advertised standalone Skill
+  package version without inferring it is a service version.
+- Preserve existing requests, authentication, scopes, service APIs, and all
+  runtime command behavior.
+
 ## 1.1.15
 
 - Add explicit read-only Knowledge support to `recall-context` through the

--- a/skills/xmemo/SKILL.md
+++ b/skills/xmemo/SKILL.md
@@ -163,9 +163,10 @@ The script supports JSON output with `--json`, command-specific usage with
 recall/search output with `--compact`. `doctor --json` adds a bounded
 `clientDiagnostics` object: a read-only discovery summary and a `nextAction`
 command for the next credential check or formal sign-in. The summary includes
-the advertised service version, MCP URL, supported clients, and standalone Skill
-operations so compatibility can be checked without inspecting the raw discovery
-document. If discovery is unavailable, `clientDiagnostics.discovery.status` is
+the advertised service version when present, MCP URL, supported clients, and
+standalone Skill package version and operations so compatibility can be checked
+without inspecting the raw discovery document. If discovery is unavailable,
+`clientDiagnostics.discovery.status` is
 `unavailable`; a successful doctor health check still succeeds. It never prints
 token values or prefixes.
 

--- a/skills/xmemo/scripts/xmemo-skill.mjs
+++ b/skills/xmemo/scripts/xmemo-skill.mjs
@@ -13,7 +13,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 
-const SKILL_VERSION = '1.1.15';
+const SKILL_VERSION = '1.1.16';
 const credentialsPath = path.join(os.homedir(), '.xmemo', 'skill-credentials.json');
 const registrationPath = path.join(os.homedir(), '.xmemo', 'skill-registration.json');
 const SCRIPT_COMMAND = 'node scripts/xmemo-skill.mjs';
@@ -448,6 +448,7 @@ function summarizeDoctorDiscovery(discovery, discoveryUrl) {
     standaloneSkill: {
       status: discoveryString(standalone.status),
       runtimeModel: discoveryString(standalone.runtime_model),
+      packageVersion: discoveryString(standalone.package?.version),
       operations: discoveryStringList(standalone.operations),
       defaultScopes: discoveryStringList(standalone.auth?.default_scopes),
     },

--- a/test/xmemo-standalone-skill.test.js
+++ b/test/xmemo-standalone-skill.test.js
@@ -223,12 +223,12 @@ test('skill script doctor --json reports bounded discovery diagnostics and a nex
         schema_version: '1.0',
         protocol: 'memory-os-agent-discovery-v1',
         service: 'memory-os',
-        service_version: '0.4.346',
         mcp_url: 'https://xmemo.dev/mcp',
         supported_clients: ['codex', 'claude-code', 'openclaw'],
         standalone_skill: {
           status: 'available',
           runtime_model: 'standalone_skill',
+          package: { version: 'skill-v1.1.16' },
           operations: ['remember', 'recall', 'doctor'],
           auth: { default_scopes: ['memory:read', 'memory:write'] },
         },
@@ -243,9 +243,10 @@ test('skill script doctor --json reports bounded discovery diagnostics and a nex
     const payload = JSON.parse(res.stdout);
     assert.equal(payload.clientDiagnostics.discovery.status, 'available');
     assert.equal(payload.clientDiagnostics.discovery.service, 'memory-os');
-    assert.equal(payload.clientDiagnostics.discovery.serviceVersion, '0.4.346');
+    assert.equal(payload.clientDiagnostics.discovery.serviceVersion, null);
     assert.equal(payload.clientDiagnostics.discovery.mcpUrl, 'https://xmemo.dev/mcp');
     assert.deepEqual(payload.clientDiagnostics.discovery.supportedClients, ['codex', 'claude-code', 'openclaw']);
+    assert.equal(payload.clientDiagnostics.discovery.standaloneSkill.packageVersion, 'skill-v1.1.16');
     assert.deepEqual(payload.clientDiagnostics.discovery.standaloneSkill.operations, ['remember', 'recall', 'doctor']);
     assert.equal(payload.clientDiagnostics.nextAction.command, 'node scripts/xmemo-skill.mjs auth status --verify');
     assert.equal(testServer.requests.length, 2);


### PR DESCRIPTION
## Summary

Preserves the bounded, read-only `doctor --json` discovery summary when public discovery omits the top-level service version: it now reports the separately advertised standalone Skill package version without treating it as a service version.

## Evidence and boundary

- Live XMemo discovery is reachable but currently omits `service_version` while publishing `standalone_skill.package.version: skill-v1.1.15`.
- Exactly 4 allowlisted files; Skill `1.1.15 -> 1.1.16`.
- No request, API, authentication, credential, scope, dependency, npm, service, or `skill-card.md` changes.

## Validation

- `verify-candidate.mjs`: passed.
- `npm run lint`: passed.
- `node --test test/xmemo-skill.test.js test/xmemo-standalone-skill.test.js`: 33/33 passed.
- `npm run pack:dry-run`: passed.